### PR TITLE
Enforce single geometry type at org-unit selection (#42)

### DIFF
--- a/src/hooks/useOrgUnitGeometry.js
+++ b/src/hooks/useOrgUnitGeometry.js
@@ -1,0 +1,45 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+import { useDataQuery } from "@dhis2/app-runtime";
+
+import { evaluateGeometrySelection } from "../util/geometry";
+
+const GEO_FEATURES_QUERY = {
+  geoFeatures: {
+    resource: "geoFeatures",
+    params: ({ ou }) => ({ ou: `ou:${ou}` }),
+  },
+};
+
+// Resolves the geometry validity of the current org-unit selection from DHIS2
+// geoFeatures, exposing the single block/warn/allow flag the wizard consumes.
+const useOrgUnitGeometry = (selectedOrgUnits = []) => {
+  const ids = selectedOrgUnits.map((orgUnit) => orgUnit.id);
+  const enabled = ids.length > 0;
+
+  const { loading, error, data } = useDataQuery(GEO_FEATURES_QUERY, {
+    lazy: !enabled,
+    variables: { ou: ids.join(";") },
+  });
+
+  const geoFeatures = data?.geoFeatures ?? [];
+
+  return {
+    loading: enabled && loading,
+    error,
+    ...evaluateGeometrySelection({ geoFeatures, selectedCount: ids.length }),
+  };
+};
+
+export default useOrgUnitGeometry;

--- a/src/hooks/useOrgUnitGeometry.test.js
+++ b/src/hooks/useOrgUnitGeometry.test.js
@@ -1,0 +1,89 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+import React from "react";
+import ReactDOM from "react-dom";
+import { act } from "react-dom/test-utils";
+import { CustomDataProvider } from "@dhis2/app-runtime";
+
+import useOrgUnitGeometry from "./useOrgUnitGeometry";
+
+// Renders the hook against fixture geoFeatures served through the
+// CustomDataProvider seam and returns the settled "valid|status|types" string.
+const Probe = ({ selected }) => {
+  const { loading, valid, status, geometryTypes } =
+    useOrgUnitGeometry(selected);
+  return (
+    <div data-testid="out">
+      {loading ? "loading" : `${valid}|${status}|${geometryTypes.join(",")}`}
+    </div>
+  );
+};
+
+const evaluate = async (geoFeatures, selected) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  await act(async () => {
+    ReactDOM.render(
+      <CustomDataProvider data={{ geoFeatures }}>
+        <Probe selected={selected} />
+      </CustomDataProvider>,
+      container
+    );
+  });
+
+  const read = () => container.querySelector('[data-testid="out"]').textContent;
+  for (let i = 0; i < 50 && read() === "loading"; i++) {
+    // flush the CustomDataProvider promise (micro + macro task) and the
+    // resulting state update
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  const text = read();
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  container.remove();
+  return text;
+};
+
+const point = (id) => ({ id, ty: 1 });
+const polygon = (id) => ({ id, ty: 2 });
+const sel = (...ids) => ids.map((id) => ({ id }));
+
+it("blocks a mixed selection through the provider seam", async () => {
+  const text = await evaluate(
+    [point("a"), polygon("b")],
+    sel("a", "b")
+  );
+  expect(text).toBe("false|mixed|Point,Polygon");
+});
+
+it("allows a single-type selection where every unit has geometry", async () => {
+  const text = await evaluate([point("a"), point("b")], sel("a", "b"));
+  expect(text).toBe("true|ok|Point");
+});
+
+it("warns but allows when only some selected units have geometry", async () => {
+  const text = await evaluate([point("a")], sel("a", "b", "c"));
+  expect(text).toBe("true|partial|Point");
+});
+
+it("allows a table-only selection when no unit has geometry", async () => {
+  const text = await evaluate([], sel("a", "b"));
+  expect(text).toBe("true|none|");
+});

--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -19,10 +19,12 @@ import {
   CalciteStepper,
   CalciteStepperItem,
   CalciteInput,
+  CalciteNotice,
 } from "@esri/calcite-components-react";
 
 import { DataDimension, PeriodDimension, dataTypeMap } from "@dhis2/analytics";
 import OrgUnitDimensionWrapper from "../components/OrgUnitDimensionWrapper";
+import useOrgUnitGeometry from "../hooks/useOrgUnitGeometry";
 import { useAuth } from "../contexts/AuthContext";
 import { useSystemSettings } from "../contexts/SystemSettingsContext";
 
@@ -76,6 +78,11 @@ const NewConnection = ({
   const [selectedOrgUnits, setSelectedOrgUnits] = useState([]);
   const [selectedDimensions, setSelectedDimensions] = useState([]);
   const [selectedPeriods, setSelectedPeriods] = useState([]);
+
+  // Single geometry-type validity for the org-unit step (issue #42).
+  const geometry = useOrgUnitGeometry(selectedOrgUnits);
+  const canLeaveOrgUnitStep =
+    selectedOrgUnits.length > 0 && !geometry.loading && geometry.valid;
 
   const [cdfParams, setCdfParams] = useState({
     tableLayout: "true",
@@ -319,10 +326,41 @@ const NewConnection = ({
             <br />
           </Description>
           <OrgUnitDimensionWrapper onChange={setSelectedOrgUnits} />
+          {selectedOrgUnits.length > 0 && geometry.status === "mixed" && (
+            <CalciteNotice open kind="danger" icon scale="m">
+              <div slot="title">{i18n.t("Mixed geometry types")}</div>
+              <div slot="message">
+                {i18n.t(
+                  "The selected organisation units resolve to more than one geometry type ({{types}}). A Connection supports a single geometry type — remove units so only one type remains, or create separate Connections.",
+                  { types: geometry.geometryTypes.join(" and ") }
+                )}
+              </div>
+            </CalciteNotice>
+          )}
+          {selectedOrgUnits.length > 0 && geometry.status === "partial" && (
+            <CalciteNotice open kind="warning" icon scale="m">
+              <div slot="title">{i18n.t("Some units have no geometry")}</div>
+              <div slot="message">
+                {i18n.t(
+                  "Some selected organisation units have no geometry. They will be included as table-only rows in the Connection."
+                )}
+              </div>
+            </CalciteNotice>
+          )}
+          {selectedOrgUnits.length > 0 && geometry.status === "none" && (
+            <CalciteNotice open kind="info" icon scale="m">
+              <div slot="title">{i18n.t("Table-only Connection")}</div>
+              <div slot="message">
+                {i18n.t(
+                  "None of the selected organisation units have geometry. This will create a table-only Connection with no map layer."
+                )}
+              </div>
+            </CalciteNotice>
+          )}
         </CalciteStepperItem>
         <CalciteStepperItem
           heading={i18n.t("Data")}
-          {...(selectedOrgUnits.length === 0 ? { disabled: true } : undefined)}
+          {...(canLeaveOrgUnitStep ? undefined : { disabled: true })}
         >
           <Description>
             <div
@@ -462,7 +500,10 @@ const NewConnection = ({
             scale="l"
             loading={isCurrentlyCreatingLayer || isCheckingName}
             onClick={handleCreateLayer}
-            {...(isLayerNameAvailable && isLayerNameValid && !isCheckingName
+            {...(isLayerNameAvailable &&
+            isLayerNameValid &&
+            !isCheckingName &&
+            geometry.valid
               ? {}
               : { disabled: true })}
           >

--- a/src/util/geometry.js
+++ b/src/util/geometry.js
@@ -1,0 +1,67 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+// Geometry type resolved from the DHIS2 geoFeatures `ty` code, never from
+// org-unit level. 1 = Point, 2 = Polygon.
+const GEOMETRY_TYPE_BY_TY = {
+  1: "Point",
+  2: "Polygon",
+};
+
+const ORDERED_GEOMETRY_TYPES = ["Point", "Polygon"];
+
+// Distinct geometry types present in the selection, ignoring units that carry
+// no geometry. Deterministically ordered so callers and tests can compare.
+export const deriveGeometryTypes = (geoFeatures = []) => {
+  const present = new Set();
+  for (const feature of geoFeatures) {
+    const type = GEOMETRY_TYPE_BY_TY[feature?.ty];
+    if (type) {
+      present.add(type);
+    }
+  }
+  return ORDERED_GEOMETRY_TYPES.filter((type) => present.has(type));
+};
+
+export const isMixedGeometry = (geoFeatures = []) =>
+  deriveGeometryTypes(geoFeatures).length > 1;
+
+// Single validity outcome the org-unit step's continue/Create control consumes.
+// - mixed: more than one geometry type -> blocked.
+// - none: no unit has geometry -> allowed (table-only Connection).
+// - partial: one type, but some selected units lack geometry -> allowed, warn.
+// - ok: one type and every selected unit has geometry -> allowed.
+export const evaluateGeometrySelection = ({
+  geoFeatures = [],
+  selectedCount = 0,
+} = {}) => {
+  const geometryTypes = deriveGeometryTypes(geoFeatures);
+
+  if (geometryTypes.length > 1) {
+    return { valid: false, status: "mixed", geometryTypes };
+  }
+
+  if (geometryTypes.length === 0) {
+    return { valid: true, status: "none", geometryTypes };
+  }
+
+  const unitsWithGeometry = geoFeatures.filter(
+    (feature) => GEOMETRY_TYPE_BY_TY[feature?.ty]
+  ).length;
+
+  if (unitsWithGeometry < selectedCount) {
+    return { valid: true, status: "partial", geometryTypes };
+  }
+
+  return { valid: true, status: "ok", geometryTypes };
+};

--- a/src/util/geometry.test.js
+++ b/src/util/geometry.test.js
@@ -1,0 +1,101 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+import {
+  deriveGeometryTypes,
+  isMixedGeometry,
+  evaluateGeometrySelection,
+} from "./geometry";
+
+// DHIS2 geoFeatures `ty`: 1 = Point, 2 = Polygon.
+const point = (id) => ({ id, ty: 1 });
+const polygon = (id) => ({ id, ty: 2 });
+
+describe("deriveGeometryTypes", () => {
+  it("returns an empty list when there are no features", () => {
+    expect(deriveGeometryTypes([])).toEqual([]);
+  });
+
+  it("resolves Point and Polygon from the geoFeatures `ty` code", () => {
+    expect(deriveGeometryTypes([point("a"), point("b")])).toEqual(["Point"]);
+    expect(deriveGeometryTypes([polygon("a")])).toEqual(["Polygon"]);
+  });
+
+  it("returns each distinct type once, deterministically ordered", () => {
+    expect(
+      deriveGeometryTypes([polygon("a"), point("b"), point("c"), polygon("d")])
+    ).toEqual(["Point", "Polygon"]);
+  });
+
+  it("ignores features that carry no geometry type", () => {
+    expect(
+      deriveGeometryTypes([point("a"), { id: "b" }, { id: "c", ty: 0 }])
+    ).toEqual(["Point"]);
+  });
+});
+
+describe("isMixedGeometry", () => {
+  it("is true when more than one geometry type is present", () => {
+    expect(isMixedGeometry([point("a"), polygon("b")])).toBe(true);
+  });
+
+  it("is false for a single geometry type", () => {
+    expect(isMixedGeometry([point("a"), point("b")])).toBe(false);
+  });
+
+  it("is false when no feature has geometry", () => {
+    expect(isMixedGeometry([{ id: "a" }, { id: "b" }])).toBe(false);
+  });
+});
+
+describe("evaluateGeometrySelection", () => {
+  it("blocks a mixed selection and names the conflicting types", () => {
+    const result = evaluateGeometrySelection({
+      geoFeatures: [point("a"), polygon("b")],
+      selectedCount: 2,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("mixed");
+    expect(result.geometryTypes).toEqual(["Point", "Polygon"]);
+  });
+
+  it("allows a single-type selection where every unit has geometry", () => {
+    const result = evaluateGeometrySelection({
+      geoFeatures: [point("a"), point("b")],
+      selectedCount: 2,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.status).toBe("ok");
+    expect(result.geometryTypes).toEqual(["Point"]);
+  });
+
+  it("warns but allows when only some selected units have geometry", () => {
+    const result = evaluateGeometrySelection({
+      geoFeatures: [point("a")],
+      selectedCount: 3,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.status).toBe("partial");
+    expect(result.geometryTypes).toEqual(["Point"]);
+  });
+
+  it("allows a table-only selection when no unit has geometry", () => {
+    const result = evaluateGeometrySelection({
+      geoFeatures: [],
+      selectedCount: 2,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.status).toBe("none");
+    expect(result.geometryTypes).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #42.

## What
Enforce a single geometry type at the organisation-unit step of the New Connection wizard.

- Geometry type is resolved from DHIS2 `geoFeatures` (`ty`: 1 = Point, 2 = Polygon), never inferred from org-unit level.
- **Mixed** selection (more than one type) is **blocked** with a danger notice naming the conflicting types (e.g. "Point and Polygon"); it gates both step-advance and the Create control.
- **Partial** selection (only some units have geometry) shows a soft **warning** but is allowed.
- **None** (no unit has geometry) is allowed and produces a table-only Connection (info notice).
- The block/allow outcome is a single validity flag (`geometry.valid`) the continue/Create control consumes.

## Test seams
- Pure reducers `deriveGeometryTypes` / `isMixedGeometry` / `evaluateGeometrySelection` — unit-tested, no mocks (`src/util/geometry.test.js`).
- Block/warn/allow behaviour verified through the `CustomDataProvider` seam with fixture `geoFeatures` (`src/hooks/useOrgUnitGeometry.test.js`).
- 15/15 new tests pass.

## Notes / out of scope
- Pre-existing failure `src/App.test.js` (imports `./App.js`; file is `App.jsx`, and App.jsx's `react-router-dom` v7 / Calcite ESM imports don't resolve under Jest) is left untouched — belongs in its own ticket.
- No lockfile or dependency changes.
