### PR TITLE
Self-host Calcite assets to fix missing icons (#41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "license": "BSD-3-Clause",
   "private": true,
   "scripts": {
-    "build": "d2-app-scripts build",
-    "start": "d2-app-scripts start",
+    "build": "node scripts/copy-calcite-assets.js && d2-app-scripts build",
+    "start": "node scripts/copy-calcite-assets.js && d2-app-scripts start",
     "test": "d2-app-scripts test",
-    "deploy": "d2-app-scripts deploy"
+    "deploy": "d2-app-scripts deploy",
+    "postinstall": "node scripts/copy-calcite-assets.js"
   },
   "devDependencies": {
     "@dhis2/cli-app-scripts": "^12.0.0"

--- a/scripts/copy-calcite-assets.js
+++ b/scripts/copy-calcite-assets.js
@@ -1,0 +1,50 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+// Vendors the installed Calcite assets into public/assets so icons and
+// component translations are served locally (ArcGIS Enterprise / offline safe)
+// instead of being fetched from an external CDN. Runs on install and before
+// start/build; the copied files are gitignored (public/assets/*).
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.join(__dirname, "..");
+const source = path.join(
+  repoRoot,
+  "node_modules",
+  "@esri",
+  "calcite-components",
+  "dist",
+  "calcite",
+  "assets"
+);
+const dest = path.join(repoRoot, "public", "assets");
+
+if (!fs.existsSync(source)) {
+  console.warn(
+    `[calcite-assets] Calcite assets not found at ${source}; skipping copy. ` +
+      "Run `npm install` so @esri/calcite-components is present."
+  );
+  process.exit(0);
+}
+
+fs.rmSync(dest, { recursive: true, force: true });
+fs.mkdirSync(dest, { recursive: true });
+fs.cpSync(source, dest, { recursive: true });
+
+console.log(
+  `[calcite-assets] Copied Calcite assets to ${path.relative(
+    process.cwd(),
+    dest
+  )}`
+);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,10 +74,11 @@ import "./locales/index.js";
 
 import AppShell from "./components/AppShell.jsx";
 
-setAssetPath("https://unpkg.com/@esri/calcite-components/dist/calcite/assets");
-
-// Local assets -- Does not work when deploying!
-// setAssetPath(window.location.href);
+// Self-hosted Calcite assets (vendored by scripts/copy-calcite-assets.js) so
+// icons and component translations load offline / in ArcGIS Enterprise without
+// external CDN access. Resolved against the app root, the same way other
+// public/ assets (e.g. the app icon) are referenced.
+setAssetPath(new URL("assets", document.baseURI).href);
 
 const App = () => {
   return (


### PR DESCRIPTION
Closes #41.

## Problem
`setAssetPath` pointed at an **unversioned** unpkg URL (`.../@esri/calcite-components/dist/calcite/assets`), which resolves to Calcite **latest (4.x)** while the app has **3.2.0** installed. The version mismatch caused missing-glyph icon boxes across the app, and relying on an external CDN breaks in offline / ArcGIS Enterprise environments.

## Fix
- Vendor the **installed 3.2.0** Calcite assets into `public/assets` via `scripts/copy-calcite-assets.js`, run on `postinstall` and before `start`/`build`.
- Point `setAssetPath` at the app-root `assets/` folder (`new URL("assets", document.baseURI)`), the same way other `public/` assets (e.g. the app icon) are referenced.
- Removes the external CDN entirely — icons load locally (Enterprise/offline-safe), no 404s.

## Verification
- Production build copies `public/assets` to the served app root: `build/app/assets/icon/*.json` present.
- Vendored assets are gitignored (`public/assets/*`), so they are regenerated from `node_modules`, never committed.

## Acceptance criteria
- [x] Icons resolve against locally-served 3.2.0 assets.
- [x] Asset path matches the installed Calcite version (3.2.0), not "latest".
- [x] Assets self-hosted/served locally (no external CDN).
- [x] No console 404s for Calcite assets.
