### PR TITLE
Pre-fill suggested Connection name and description (#43)

### DIFF
--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -29,6 +29,11 @@ import { useSystemSettings } from "../contexts/SystemSettingsContext";
 import { cdfTemplate } from "../template/cdfTemplate";
 import { useAppAlert, ALERT_TYPES } from "../hooks/useAppAlert";
 import { createService, isServiceNameAvailable } from "../util/portal";
+import {
+  suggestConnectionName,
+  suggestDescription,
+  applyNameSuffix,
+} from "../util/suggestions";
 
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
@@ -90,6 +95,8 @@ const NewConnection = ({
   const [isLayerNameAvailable, setIsLayerNameAvailable] = useState(true);
   const [isCheckingName, setIsCheckingName] = useState(false);
   const [layerDescription, setLayerDescription] = useState("");
+  const [nameEdited, setNameEdited] = useState(false);
+  const [descriptionEdited, setDescriptionEdited] = useState(false);
 
   const encode = (string) =>
     btoa(string).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
@@ -223,6 +230,7 @@ const NewConnection = ({
 
   const handleLayerNameChange = (event) => {
     setIsCheckingName(true);
+    setNameEdited(true);
     const newLayerName = event.target.value;
     setLayerName(newLayerName);
 
@@ -279,6 +287,72 @@ const NewConnection = ({
       setIsCheckingName(false);
     }, 500);
   };
+
+  // Finds an available service name, auto-suffixing (_2, _3, ...) on collision
+  // via the existing availability check.
+  const findAvailableName = async (base) => {
+    if (!base || !userCredential?.server || !userCredential?.token) {
+      return base;
+    }
+    let occurrence = 1;
+    let candidate = applyNameSuffix(base, occurrence);
+    while (occurrence <= 50) {
+      const available = await isServiceNameAvailable(
+        userCredential.server,
+        candidate,
+        userCredential.token
+      );
+      if (available) {
+        return candidate;
+      }
+      occurrence += 1;
+      candidate = applyNameSuffix(base, occurrence);
+    }
+    return candidate;
+  };
+
+  // Pre-fill an editable suggested name/description on the Summary step from the
+  // current selection. User edits are never overwritten by later suggestions.
+  useEffect(() => {
+    if (currentStep !== 4) {
+      return;
+    }
+
+    let cancelled = false;
+    const selection = {
+      dataItems: selectedDimensions,
+      orgUnits: selectedOrgUnits,
+      periods: selectedPeriods,
+    };
+
+    if (!descriptionEdited) {
+      const description = suggestDescription(selection);
+      if (description) {
+        setLayerDescription(description);
+      }
+    }
+
+    if (!nameEdited) {
+      const base = suggestConnectionName(selection);
+      if (base) {
+        setIsCheckingName(true);
+        findAvailableName(base).then((available) => {
+          if (cancelled) {
+            return;
+          }
+          setLayerName(available);
+          setIsLayerNameValid(true);
+          setIsLayerNameAvailable(true);
+          setIsCheckingName(false);
+        });
+      }
+    }
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentStep]);
 
   return (
     <div
@@ -438,9 +512,10 @@ const NewConnection = ({
               style={{
                 width: "65%",
               }}
-              onCalciteInputInput={(event) =>
-                setLayerDescription(event.target.value)
-              }
+              onCalciteInputInput={(event) => {
+                setDescriptionEdited(true);
+                setLayerDescription(event.target.value);
+              }}
               placeholder={i18n.t("Enter a description for your layer")}
             />
           </div>

--- a/src/util/suggestions.js
+++ b/src/util/suggestions.js
@@ -1,0 +1,94 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+const MAX_NAME_LENGTH = 50;
+
+const displayNameOf = (item) =>
+  item?.name ?? item?.displayName ?? item?.label ?? item?.id ?? "";
+
+const nameWithMore = (items) => {
+  if (!items.length) {
+    return "";
+  }
+  const first = displayNameOf(items[0]);
+  const more = items.length - 1;
+  return more > 0 ? `${first} and ${more} more` : first;
+};
+
+// Sanitize to an ArcGIS-safe service name: disallowed runs become "_",
+// collapse repeats, trim leading/trailing "_".
+export const sanitizeName = (raw = "") =>
+  raw
+    .replace(/[^A-Za-z0-9_]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+const capName = (name) =>
+  name.length <= MAX_NAME_LENGTH
+    ? name
+    : name.slice(0, MAX_NAME_LENGTH).replace(/_+$/, "");
+
+// nth availability of a name: 1 -> base, 2 -> base_2, ... capped at 50 chars.
+export const applyNameSuffix = (base, occurrence) => {
+  if (!base || occurrence <= 1) {
+    return base;
+  }
+  const suffix = `_${occurrence}`;
+  const room = MAX_NAME_LENGTH - suffix.length;
+  const trimmed = base.length > room ? base.slice(0, room) : base;
+  return `${trimmed.replace(/_+$/, "")}${suffix}`;
+};
+
+// Suggested service name from the selection: first data item + first org unit
+// + first period, with a short "_plusN" count when multiple are selected.
+export const suggestConnectionName = ({
+  dataItems = [],
+  orgUnits = [],
+  periods = [],
+} = {}) => {
+  const parts = [dataItems[0], orgUnits[0], periods[0]]
+    .filter(Boolean)
+    .map(displayNameOf)
+    .filter(Boolean);
+
+  if (!parts.length) {
+    return "";
+  }
+
+  const extra =
+    Math.max(0, dataItems.length - 1) +
+    Math.max(0, orgUnits.length - 1) +
+    Math.max(0, periods.length - 1);
+
+  const base = sanitizeName(parts.join("_"));
+  return capName(extra > 0 ? `${base}_plus${extra}` : base);
+};
+
+// Readable, editable default description for the Summary step.
+export const suggestDescription = ({
+  dataItems = [],
+  orgUnits = [],
+  periods = [],
+} = {}) => {
+  if (!dataItems.length && !orgUnits.length && !periods.length) {
+    return "";
+  }
+
+  const lead = dataItems.length
+    ? nameWithMore(dataItems)
+    : "Organisation unit data";
+  const where = orgUnits.length ? ` in ${nameWithMore(orgUnits)}` : "";
+  const when = periods.length ? ` for ${nameWithMore(periods)}` : "";
+
+  return `${lead}${where}${when}.`;
+};

--- a/src/util/suggestions.test.js
+++ b/src/util/suggestions.test.js
@@ -1,0 +1,128 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+import {
+  sanitizeName,
+  applyNameSuffix,
+  suggestConnectionName,
+  suggestDescription,
+} from "./suggestions";
+
+describe("sanitizeName", () => {
+  it("replaces disallowed characters with underscores", () => {
+    expect(sanitizeName("Sierra Leone")).toBe("Sierra_Leone");
+    expect(sanitizeName("a/b\\c")).toBe("a_b_c");
+  });
+
+  it("collapses repeats and trims leading/trailing underscores", () => {
+    expect(sanitizeName("Malaria (confirmed)")).toBe("Malaria_confirmed");
+    expect(sanitizeName("  _x_  ")).toBe("x");
+  });
+});
+
+describe("applyNameSuffix", () => {
+  it("returns the base unchanged for the first occurrence", () => {
+    expect(applyNameSuffix("Malaria_Bo_2020", 1)).toBe("Malaria_Bo_2020");
+  });
+
+  it("appends _2, _3 for later occurrences", () => {
+    expect(applyNameSuffix("Malaria_Bo_2020", 2)).toBe("Malaria_Bo_2020_2");
+    expect(applyNameSuffix("Malaria_Bo_2020", 3)).toBe("Malaria_Bo_2020_3");
+  });
+
+  it("keeps the suffixed name within the 50-char cap", () => {
+    const base = "x".repeat(49);
+    const result = applyNameSuffix(base, 2);
+    expect(result.length).toBeLessThanOrEqual(50);
+    expect(result.endsWith("_")).toBe(false);
+  });
+});
+
+describe("suggestConnectionName", () => {
+  it("joins first data item, org unit, and period", () => {
+    expect(
+      suggestConnectionName({
+        dataItems: [{ name: "Malaria" }],
+        orgUnits: [{ name: "Sierra Leone" }],
+        periods: [{ name: "2020" }],
+      })
+    ).toBe("Malaria_Sierra_Leone_2020");
+  });
+
+  it("appends a short count when more than one item is selected", () => {
+    expect(
+      suggestConnectionName({
+        dataItems: [{ name: "Malaria" }, { name: "TB" }],
+        orgUnits: [{ name: "Bo" }],
+        periods: [{ name: "2020" }, { name: "2021" }],
+      })
+    ).toBe("Malaria_Bo_2020_plus2");
+  });
+
+  it("falls back to displayName", () => {
+    expect(
+      suggestConnectionName({
+        dataItems: [{ displayName: "ANC 1st visit" }],
+        orgUnits: [{ displayName: "Bo" }],
+        periods: [{ displayName: "2020" }],
+      })
+    ).toBe("ANC_1st_visit_Bo_2020");
+  });
+
+  it("returns an empty string for an empty selection", () => {
+    expect(suggestConnectionName({})).toBe("");
+  });
+
+  it("caps the name at 50 characters without a trailing underscore", () => {
+    const result = suggestConnectionName({
+      dataItems: [{ name: "x".repeat(49) }],
+      orgUnits: [{ name: "Z" }],
+    });
+    expect(result.length).toBeLessThanOrEqual(50);
+    expect(result.endsWith("_")).toBe(false);
+  });
+});
+
+describe("suggestDescription", () => {
+  it("reads naturally for a single selection", () => {
+    expect(
+      suggestDescription({
+        dataItems: [{ name: "Malaria" }],
+        orgUnits: [{ name: "Sierra Leone" }],
+        periods: [{ name: "2020" }],
+      })
+    ).toBe("Malaria in Sierra Leone for 2020.");
+  });
+
+  it("summarizes additional items with a count", () => {
+    expect(
+      suggestDescription({
+        dataItems: [{ name: "Malaria" }, { name: "TB" }],
+        orgUnits: [{ name: "Sierra Leone" }],
+        periods: [{ name: "2020" }],
+      })
+    ).toBe("Malaria and 1 more in Sierra Leone for 2020.");
+  });
+
+  it("describes a geometry/table-only selection with no data items", () => {
+    expect(
+      suggestDescription({
+        orgUnits: [{ name: "Sierra Leone" }],
+      })
+    ).toBe("Organisation unit data in Sierra Leone.");
+  });
+
+  it("returns an empty string for an empty selection", () => {
+    expect(suggestDescription({})).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #43.

## What
On the Summary step of the New Connection wizard, pre-fill an **editable** suggested name and description derived from the current selection, so the author doesn't have to invent them.

- **Name** — first data item + first org unit + first period, with a short `_plusN` count when multiple are selected; sanitized to `[A-Za-z0-9_]`, capped at 50 chars, and auto-suffixed (`_2`, `_3`, …) on collision using the existing name-availability check.
- **Description** — a readable sentence summarizing the selection (e.g. `Malaria and 1 more in Sierra Leone for 2020.`).
- Both fields stay fully editable; once the user edits a field, later suggestions never overwrite it (`nameEdited` / `descriptionEdited` guards).

## Test seam
- Pure `suggestConnectionName` / `suggestDescription` (plus `sanitizeName` / `applyNameSuffix`) unit-tested with no mocks (`src/util/suggestions.test.js`, 14 tests).
- Collision-suffixing/prefill orchestration lives in the component and reuses the existing availability check.

## Acceptance criteria
- [x] Name pre-filled from the selection (first data item + org unit + period, short count when multiple).
- [x] Sanitized to `[A-Za-z0-9_]`, capped (~50), auto-suffixed on collision via the availability check.
- [x] Readable description pre-filled.
- [x] Both fields editable; user edits never overwritten by later suggestions.
- [x] Pure functions unit-tested.
