### PR TITLE
Remove a Connection from within the app (#45)

### DIFF
--- a/src/pages/Connections.jsx
+++ b/src/pages/Connections.jsx
@@ -18,17 +18,19 @@ import styled from "styled-components";
 import i18n from "@dhis2/d2-i18n";
 
 import { useAuth } from "../contexts/AuthContext";
+import { useAppAlert, ALERT_TYPES } from "../hooks/useAppAlert";
 import {
   CalciteTable,
   CalciteTableHeader,
   CalciteTableRow,
   CalciteTableCell,
   CalciteButton,
+  CalciteDialog,
   CalcitePagination,
 } from "@esri/calcite-components-react";
 
 import { useNavigate } from "react-router-dom";
-import { queryForServices } from "../util/portal";
+import { queryForServices, deleteConnection } from "../util/portal";
 
 const StyledContainer = styled.div`
   padding: 1rem;
@@ -47,7 +49,9 @@ const StyledPageHeader = styled.h1`
 const Connections = () => {
   const navigate = useNavigate();
 
-  const { userCredential, portalProperties } = useAuth();
+  const { userCredential, userInformation, hostingServerProperties } =
+    useAuth();
+  const { showAlert } = useAppAlert();
 
   const [services, setServices] = useState([]);
 
@@ -55,6 +59,10 @@ const Connections = () => {
     key: "created",
     direction: "desc",
   });
+
+  // The Connection awaiting delete confirmation, and the id being deleted.
+  const [connectionToDelete, setConnectionToDelete] = useState(null);
+  const [deletingId, setDeletingId] = useState(null);
 
   async function fetchServices() {
     const response = await queryForServices(
@@ -115,6 +123,52 @@ const Connections = () => {
     return sortConfig.direction === "asc" ? "sorted asc" : "sorted desc";
   };
 
+  // The CDF service name lives in the item URL (.../rest/services/<name>/FeatureServer).
+  const getServiceName = (service) => {
+    const afterServices = service.url?.split("/rest/services/")[1];
+    return afterServices ? afterServices.split("/")[0] : service.name;
+  };
+
+  const isOwnedByCurrentUser = (service) =>
+    userInformation?.username != null &&
+    userInformation.username === service.owner;
+
+  const handleConfirmDelete = async () => {
+    const service = connectionToDelete;
+    if (!service) return;
+
+    setDeletingId(service.id);
+    try {
+      await deleteConnection({
+        portalUrl: userCredential.server,
+        hostingServerUrl: hostingServerProperties.url,
+        owner: service.owner,
+        itemId: service.id,
+        serviceName: getServiceName(service),
+        token: userCredential.token,
+      });
+      setServices((prev) => prev.filter((s) => s.id !== service.id));
+      setConnectionToDelete(null);
+      showAlert({
+        title: i18n.t("Connection removed"),
+        message: i18n.t(
+          "The Connection and its ArcGIS artifacts were permanently deleted."
+        ),
+        type: ALERT_TYPES.SUCCESS,
+      });
+    } catch (err) {
+      console.error("Error removing connection", err);
+      showAlert({
+        title: i18n.t("Error removing Connection"),
+        autoClose: false,
+        message: err?.message || String(err),
+        type: ALERT_TYPES.DANGER,
+      });
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
   return (
     <StyledContainer>
       <div
@@ -146,7 +200,7 @@ const Connections = () => {
       </div>
       <div>
         {i18n.t(
-          "Connections are live feeds to your DHIS2 data. The data remains in DHIS2. To delete connections, you can do so from the ArcGIS Enterprise portal."
+          "Connections are live feeds to your DHIS2 data. The data remains in DHIS2. You can remove Connections you own directly from this page."
         )}
       </div>
 
@@ -194,6 +248,10 @@ const Connections = () => {
               heading="View in ArcGIS"
               alignment="center"
             ></CalciteTableHeader>
+            <CalciteTableHeader
+              heading="Remove"
+              alignment="center"
+            ></CalciteTableHeader>
           </CalciteTableRow>
 
           {sortedData.map((service) => (
@@ -217,11 +275,61 @@ const Connections = () => {
                   {i18n.t("Open")}
                 </CalciteButton>
               </CalciteTableCell>
+              <CalciteTableCell alignment="center">
+                {isOwnedByCurrentUser(service) && (
+                  <CalciteButton
+                    scale="m"
+                    appearance="transparent"
+                    kind="danger"
+                    iconStart="trash"
+                    loading={deletingId === service.id}
+                    disabled={deletingId !== null}
+                    onClick={() => setConnectionToDelete(service)}
+                  >
+                    {i18n.t("Remove")}
+                  </CalciteButton>
+                )}
+              </CalciteTableCell>
             </CalciteTableRow>
           ))}
         </CalciteTable>
       )}
-      {/* <CalcitePagination
+
+      <CalciteDialog
+        modal
+        kind="danger"
+        open={connectionToDelete !== null}
+        heading={i18n.t("Remove Connection")}
+        escapeDisabled={deletingId !== null}
+        outsideCloseDisabled={deletingId !== null}
+        onCalciteDialogClose={() => {
+          if (deletingId === null) setConnectionToDelete(null);
+        }}
+      >
+        <div>
+          {i18n.t(
+            'This permanently deletes the feature layer "{{title}}" and will break anything using it in ArcGIS Enterprise. This action cannot be undone.',
+            { title: connectionToDelete?.title }
+          )}
+        </div>
+        <CalciteButton
+          slot="secondary"
+          appearance="outline"
+          disabled={deletingId !== null}
+          onClick={() => setConnectionToDelete(null)}
+        >
+          {i18n.t("Cancel")}
+        </CalciteButton>
+        <CalciteButton
+          slot="primary"
+          kind="danger"
+          iconStart="trash"
+          loading={deletingId !== null}
+          onClick={handleConfirmDelete}
+        >
+          {i18n.t("Remove")}
+        </CalciteButton>
+      </CalciteDialog>
         pageSize={10}
         startItem={0}
         totalItems={sortedData.length}

--- a/src/util/portal.js
+++ b/src/util/portal.js
@@ -75,3 +75,60 @@ export async function isServiceNameAvailable(server, serviceName, token) {
     ? false
     : true;
 }
+
+async function postForm(url, token) {
+  const body = new URLSearchParams({ f: "json", token }).toString();
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  return response.json();
+}
+
+export async function deleteCdfService(
+  hostingServerUrl,
+  serviceName,
+  token,
+  serviceType = "FeatureServer"
+) {
+  const url = `${hostingServerUrl}/admin/services/${serviceName}.${serviceType}/delete`;
+  const data = await postForm(url, token);
+  if (data?.status === "error") {
+    throw new Error(
+      data.messages?.join("; ") || "Failed to delete the CDF service."
+    );
+  }
+  return data;
+}
+
+export async function deletePortalItem(portalUrl, owner, itemId, token) {
+  const url = `${portalUrl}/sharing/rest/content/users/${owner}/items/${itemId}/delete`;
+  const data = await postForm(url, token);
+  if (data?.error) {
+    throw new Error(data.error.message || "Failed to delete the portal item.");
+  }
+  return data;
+}
+
+// Removes both ArcGIS artifacts behind a Connection: the CDF service (admin) is
+// deleted first so the portal item delete can't race a cascade. Reused by both
+// Remove-a-Connection and Preview's Discard.
+export async function deleteConnection({
+  portalUrl,
+  hostingServerUrl,
+  owner,
+  itemId,
+  serviceName,
+  token,
+  serviceType = "FeatureServer",
+}) {
+  const service = await deleteCdfService(
+    hostingServerUrl,
+    serviceName,
+    token,
+    serviceType
+  );
+  const item = await deletePortalItem(portalUrl, owner, itemId, token);
+  return { service, item };
+}

--- a/src/util/portal.test.js
+++ b/src/util/portal.test.js
@@ -1,0 +1,102 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+// @arcgis/core ships ESM that jest doesn't transform; portal.js only imports it
+// at module load, so stub it out to keep this seam test focused on fetch.
+jest.mock("@arcgis/core/request.js", () => ({ default: jest.fn() }));
+
+import { deleteConnection } from "./portal";
+
+function okJson(data) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+}
+
+const baseArgs = {
+  portalUrl: "https://example.com/portal",
+  hostingServerUrl: "https://example.com/server",
+  owner: "jdoe",
+  itemId: "abc123",
+  serviceName: "my_connection",
+  token: "t0ken",
+};
+
+describe("deleteConnection", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("deletes the CDF service, then the portal item, and aggregates results", async () => {
+    global.fetch
+      .mockReturnValueOnce(okJson({ status: "success" }))
+      .mockReturnValueOnce(okJson({ success: true, itemId: "abc123" }));
+
+    const result = await deleteConnection(baseArgs);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    const firstUrl = global.fetch.mock.calls[0][0];
+    const secondUrl = global.fetch.mock.calls[1][0];
+
+    // CDF service (admin) is deleted first so the portal item delete can't
+    // race a cascade.
+    expect(firstUrl).toBe(
+      "https://example.com/server/admin/services/my_connection.FeatureServer/delete"
+    );
+    expect(secondUrl).toBe(
+      "https://example.com/portal/sharing/rest/content/users/jdoe/items/abc123/delete"
+    );
+
+    expect(result).toEqual({
+      service: { status: "success" },
+      item: { success: true, itemId: "abc123" },
+    });
+  });
+
+  it("sends f=json and the token in each POST body", async () => {
+    global.fetch
+      .mockReturnValueOnce(okJson({ status: "success" }))
+      .mockReturnValueOnce(okJson({ success: true }));
+
+    await deleteConnection(baseArgs);
+
+    for (const call of global.fetch.mock.calls) {
+      const options = call[1];
+      expect(options.method).toBe("POST");
+      const params = new URLSearchParams(options.body);
+      expect(params.get("f")).toBe("json");
+      expect(params.get("token")).toBe("t0ken");
+    }
+  });
+
+  it("throws and skips the item delete when the CDF service delete fails", async () => {
+    global.fetch.mockReturnValueOnce(
+      okJson({ status: "error", messages: ["boom"] })
+    );
+
+    await expect(deleteConnection(baseArgs)).rejects.toThrow("boom");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the portal item delete reports an error", async () => {
+    global.fetch
+      .mockReturnValueOnce(okJson({ status: "success" }))
+      .mockReturnValueOnce(okJson({ error: { message: "no permission" } }));
+
+    await expect(deleteConnection(baseArgs)).rejects.toThrow("no permission");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #45.

## What

Lets a Connection's owner delete it from within the app. Introduces a reusable `deleteConnection` capability on the `portal.js` seam that Preview's Discard can also reuse.

## Changes

- **`src/util/portal.js`** — new `deleteConnection` (plus `deleteCdfService` / `deletePortalItem` helpers). Deletes the CDF service first (admin endpoint), then the portal item, so the item delete can't race a cascade. Either failure throws with the server's message.
- **`src/pages/Connections.jsx`** — owner-only Remove action (`service.owner === userInformation.username`), a strong danger confirmation dialog that names the layer and warns it breaks anything using it in ArcGIS Enterprise, a busy/disabled row state during deletion, row removal on success, and an error alert on failure. Updated the outdated `delete from the ArcGIS portal` helper text.
- **`src/util/portal.test.js`** — tests the seam by mocking `fetch`: correct URLs and order, `f=json`+token in each POST body, and error propagation (service failure skips the item delete).

## Acceptance criteria

- [x] Remove appears only on Connections owned by the signed-in user.
- [x] Guarded by a strong confirmation stating it permanently deletes the feature layer and will break ArcGIS Enterprise usage.
- [x] Confirming deletes both the portal item and the CDF service.
- [x] Row shows a busy/disabled state during deletion and is removed on success; failures surface an error.
- [x] Reusable `deleteConnection` capability introduced and tested through the `portal.js` seam.

## Notes

- On the cascade question in the AC: item-delete cascading to an admin-registered CDF service isn't confirmed, so both delete calls are kept. Deleting the CDF service first makes the sequence deterministic.
- Branch is off `main` and independent of the still-open PRs #50–52.
- Pre-existing `App.test.js` failure (imports `./App.js`) is unrelated to this change.