### PR TITLE
Refresh connections and auto-appear after create (#44)

### DIFF
--- a/src/pages/Connections.jsx
+++ b/src/pages/Connections.jsx
@@ -27,8 +27,8 @@ import {
   CalcitePagination,
 } from "@esri/calcite-components-react";
 
-import { useNavigate } from "react-router-dom";
-import { queryForServices } from "../util/portal";
+import { useNavigate, useLocation } from "react-router-dom";
+import { queryForServices, pollForServices } from "../util/portal";
 
 const StyledContainer = styled.div`
   padding: 1rem;
@@ -46,27 +46,51 @@ const StyledPageHeader = styled.h1`
 
 const Connections = () => {
   const navigate = useNavigate();
+  const location = useLocation();
 
-  const { userCredential, portalProperties } = useAuth();
+  const { userCredential } = useAuth();
 
   const [services, setServices] = useState([]);
+  const [isRefreshing, setIsRefreshing] = useState(false);
 
   const [sortConfig, setSortConfig] = useState({
     key: "created",
     direction: "desc",
   });
 
-  async function fetchServices() {
-    const response = await queryForServices(
-      userCredential.server,
-      userCredential.token
-    );
-    console.log(response);
-    setServices(response);
-  }
+  const fetchServices = async () => {
+    setIsRefreshing(true);
+    try {
+      const response = await queryForServices(
+        userCredential.server,
+        userCredential.token
+      );
+      setServices(response || []);
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
 
   useEffect(() => {
-    if (userCredential) {
+    if (!userCredential) return;
+
+    // A freshly created Connection may lag the ArcGIS search index, so poll for
+    // it instead of a single fetch. The title is handed over via nav state.
+    const newConnectionTitle = location.state?.newConnectionTitle;
+    if (newConnectionTitle) {
+      // Clear nav state so a later manual refresh doesn't re-trigger the poll.
+      navigate(location.pathname, { replace: true, state: {} });
+      setIsRefreshing(true);
+      pollForServices({
+        server: userCredential.server,
+        token: userCredential.token,
+        predicate: (service) =>
+          service.title === newConnectionTitle ||
+          service.name === newConnectionTitle,
+      })
+        .then((results) => setServices(results || []))
+        .finally(() => setIsRefreshing(false));
+    } else {
       fetchServices();
     }
   }, [userCredential]);
@@ -134,6 +158,17 @@ const Connections = () => {
           }}
         >
           {i18n.t("Add New Connection")}
+        </CalciteButton>
+        <CalciteButton
+          style={{ marginLeft: "0.5rem" }}
+          scale="l"
+          appearance="outline"
+          iconStart="refresh"
+          loading={isRefreshing}
+          disabled={isRefreshing}
+          onClick={fetchServices}
+        >
+          {i18n.t("Refresh")}
         </CalciteButton>
       </div>
       <div

--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -199,7 +199,9 @@ const NewConnection = ({
           ),
           type: ALERT_TYPES.SUCCESS,
         });
-        navigate("/connections");
+        navigate("/connections", {
+          state: { newConnectionTitle: layerName },
+        });
       } else {
         showAlert({
           title: i18n.t("Error creating layer"),

--- a/src/util/portal.js
+++ b/src/util/portal.js
@@ -28,6 +28,32 @@ export async function queryForServices(server, token) {
   return response.data?.results;
 }
 
+// Bounded poll that re-pulls the Connections list until `predicate` matches a
+// result (covering ArcGIS search-index lag after a create) or attempts run out.
+// Returns the most recent results either way. `query` and `wait` are injectable
+// for testing.
+export async function pollForServices({
+  server,
+  token,
+  predicate,
+  attempts = 5,
+  delayMs = 1500,
+  query = queryForServices,
+  wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
+  let results = [];
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    results = (await query(server, token)) || [];
+    if (results.some(predicate)) {
+      return results;
+    }
+    if (attempt < attempts - 1) {
+      await wait(delayMs);
+    }
+  }
+  return results;
+}
+
 export async function getUserInfo(portalUrl, userId, token) {
   const userInfoUrl = `${portalUrl}/sharing/rest/community/users/${userId}?f=json&token=${token}`;
   const userInfoResponse = await fetch(userInfoUrl);

--- a/src/util/portal.test.js
+++ b/src/util/portal.test.js
@@ -1,0 +1,94 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+// @arcgis/core ships ESM that jest doesn't transform; portal.js only imports it
+// at module load, so stub it out to keep this seam test focused on the poll.
+jest.mock("@arcgis/core/request.js", () => ({ default: jest.fn() }));
+
+import { pollForServices } from "./portal";
+
+const byTitle = (title) => (service) => service.title === title;
+const noWait = jest.fn().mockResolvedValue(undefined);
+
+describe("pollForServices", () => {
+  it("returns immediately when the predicate matches on the first pull", async () => {
+    const query = jest.fn().mockResolvedValue([{ title: "existing" }]);
+
+    const results = await pollForServices({
+      server: "s",
+      token: "t",
+      predicate: byTitle("existing"),
+      query,
+      wait: noWait,
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(noWait).not.toHaveBeenCalled();
+    expect(results).toEqual([{ title: "existing" }]);
+  });
+
+  it("keeps polling (with a wait between attempts) until the row appears", async () => {
+    const wait = jest.fn().mockResolvedValue(undefined);
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ title: "other" }])
+      .mockResolvedValueOnce([{ title: "other" }, { title: "new_layer" }]);
+
+    const results = await pollForServices({
+      server: "s",
+      token: "t",
+      predicate: byTitle("new_layer"),
+      attempts: 5,
+      query,
+      wait,
+    });
+
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenCalledTimes(2);
+    expect(results.some(byTitle("new_layer"))).toBe(true);
+  });
+
+  it("gives up after the bounded number of attempts and returns the last results", async () => {
+    const wait = jest.fn().mockResolvedValue(undefined);
+    const query = jest.fn().mockResolvedValue([{ title: "other" }]);
+
+    const results = await pollForServices({
+      server: "s",
+      token: "t",
+      predicate: byTitle("never"),
+      attempts: 3,
+      query,
+      wait,
+    });
+
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenCalledTimes(2);
+    expect(results).toEqual([{ title: "other" }]);
+  });
+
+  it("tolerates a query that resolves to null/undefined", async () => {
+    const query = jest.fn().mockResolvedValue(undefined);
+
+    const results = await pollForServices({
+      server: "s",
+      token: "t",
+      predicate: byTitle("anything"),
+      attempts: 2,
+      query,
+      wait: noWait,
+    });
+
+    expect(results).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #44.

## What

On the Connections page: a Refresh control re-pulls the list on demand, and a newly created Connection appears on its own without a full page reload.

## Changes

- **`src/util/portal.js`** — new `pollForServices`: a bounded poll that re-pulls the Connections list until a predicate matches (covering ArcGIS search-index lag) or attempts run out, returning the latest results either way. `query` and `wait` are injectable for testing.
- **`src/pages/Connections.jsx`** — a busy-stated Refresh button beside Add New Connection; on arrival from a create it reads the new Connection title from nav state and polls until the row appears (then clears the nav state so a later manual refresh doesn't re-poll).
- **`src/pages/NewConnection.jsx`** — on successful create, navigates to `/connections` with the new title in nav state.
- **`src/util/portal.test.js`** — seam tests for `pollForServices`: immediate match, poll-until-appears (with waits between), bounded give-up, and null-tolerance.

## Acceptance criteria

- [x] A Refresh control re-pulls the Connections list on demand.
- [x] After a Connection is created, the new row appears without a full page reload (bounded post-create poll covers search-index lag).
- [x] Refresh shows a busy state while fetching.

## Notes

- Branch is off `main` and independent of PRs #50–53.
- Pre-existing `App.test.js` failure (imports `./App.js`) is unrelated.