### PR TITLE
Sortable table affordances (#46)

### DIFF
--- a/src/pages/Connections.jsx
+++ b/src/pages/Connections.jsx
@@ -31,6 +31,7 @@ import {
 
 import { useNavigate } from "react-router-dom";
 import { queryForServices, deleteConnection } from "../util/portal";
+import { getSortIndicator } from "../util/sort";
 
 const StyledContainer = styled.div`
   padding: 1rem;
@@ -118,10 +119,7 @@ const Connections = () => {
     setSortConfig({ key, direction });
   };
 
-  const getArrow = (key) => {
-    if (sortConfig.key !== key) return null;
-    return sortConfig.direction === "asc" ? "sorted asc" : "sorted desc";
-  };
+  const getSortGlyph = (key) => getSortIndicator(key, sortConfig).glyph;
 
   // The CDF service name lives in the item URL (.../rest/services/<name>/FeatureServer).
   const getServiceName = (service) => {
@@ -223,25 +221,25 @@ const Connections = () => {
               heading="Title"
               style={{ cursor: "pointer" }}
               onClick={() => requestSort("title")}
-              description={getArrow("title")}
+              description={getSortGlyph("title")}
             ></CalciteTableHeader>
             <CalciteTableHeader
               heading="Description"
               onClick={() => requestSort("description")}
               style={{ cursor: "pointer" }}
-              description={getArrow("description")}
+              description={getSortGlyph("description")}
             ></CalciteTableHeader>
             {/* <CalciteTableHeader heading="URL"></CalciteTableHeader> */}
             <CalciteTableHeader
               heading="Created By"
               onClick={() => requestSort("owner")}
               style={{ cursor: "pointer" }}
-              description={getArrow("owner")}
+              description={getSortGlyph("owner")}
             ></CalciteTableHeader>
             <CalciteTableHeader
               style={{ cursor: "pointer" }}
               onClick={() => requestSort("created")}
-              description={getArrow("created")}
+              description={getSortGlyph("created")}
               heading="Created On"
             ></CalciteTableHeader>
             <CalciteTableHeader

--- a/src/util/sort.js
+++ b/src/util/sort.js
@@ -1,0 +1,31 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+// calcite-table-header renders `description` as plain text (no slot for a
+// calcite-icon), so the sort affordance is a text glyph.
+export const NEUTRAL_GLYPH = "\u21C5"; // ⇅ up/down arrows: this column can be sorted
+export const ASC_GLYPH = "\u25B2"; // ▲
+export const DESC_GLYPH = "\u25BC"; // ▼
+
+// Maps a column against the current sort state to its header glyph. `label` is
+// suitable for assistive text; `direction` is null when the column is sortable
+// but not the active sort.
+export function getSortIndicator(columnKey, sortConfig) {
+  const isActive = sortConfig?.key === columnKey;
+  if (!isActive) {
+    return { glyph: NEUTRAL_GLYPH, label: "Sortable", direction: null };
+  }
+  return sortConfig.direction === "asc"
+    ? { glyph: ASC_GLYPH, label: "Sorted ascending", direction: "asc" }
+    : { glyph: DESC_GLYPH, label: "Sorted descending", direction: "desc" };
+}

--- a/src/util/sort.test.js
+++ b/src/util/sort.test.js
@@ -1,0 +1,51 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+import { NEUTRAL_GLYPH, ASC_GLYPH, DESC_GLYPH, getSortIndicator } from "./sort";
+
+describe("getSortIndicator", () => {
+  it("shows a neutral glyph on a sortable column that isn't the active sort", () => {
+    const indicator = getSortIndicator("title", {
+      key: "created",
+      direction: "desc",
+    });
+
+    expect(indicator.glyph).toBe(NEUTRAL_GLYPH);
+    expect(indicator.direction).toBeNull();
+  });
+
+  it("shows an ascending glyph on the active column sorted ascending", () => {
+    const indicator = getSortIndicator("owner", {
+      key: "owner",
+      direction: "asc",
+    });
+
+    expect(indicator.glyph).toBe(ASC_GLYPH);
+    expect(indicator.direction).toBe("asc");
+  });
+
+  it("shows a descending glyph on the active column sorted descending", () => {
+    const indicator = getSortIndicator("owner", {
+      key: "owner",
+      direction: "desc",
+    });
+
+    expect(indicator.glyph).toBe(DESC_GLYPH);
+    expect(indicator.direction).toBe("desc");
+  });
+
+  it("falls back to the neutral glyph when there is no sort config", () => {
+    expect(getSortIndicator("title", undefined).glyph).toBe(NEUTRAL_GLYPH);
+    expect(getSortIndicator("title", {}).glyph).toBe(NEUTRAL_GLYPH);
+  });
+});


### PR DESCRIPTION
Closes #46. Unblocked by #41 (Calcite icons), now merged.

## What

Makes the Connections table's sort state legible.

## Changes

- **`src/util/sort.js`** — new `getSortIndicator(columnKey, sortConfig)` returning the header glyph, an assistive `label`, and the active `direction`.
- **`src/pages/Connections.jsx`** — sortable headers now render that glyph in their `description`: a neutral up/down glyph (`⇅`) when sortable-but-inactive, and a direction triangle (`▲`/`▼`) on the active column that toggles on click. Sorting logic is unchanged.
- **`src/util/sort.test.js`** — seam tests for neutral / ascending / descending / no-config cases.

## Acceptance criteria

- [x] Sortable-but-unsorted columns show a neutral sort glyph.
- [x] The active sort column shows a direction glyph that toggles on click.
- [x] Sorting behavior remains correct for every column.

## Implementation note

`calcite-table-header` renders `heading`/`description` as plain text and exposes **no slot**, so a `<calcite-icon>` can't be nested in a header cell (verified against `@esri/calcite-components` 3.2.0). The affordance is therefore a Unicode glyph in the existing `description` prop rather than a `calcite-icon`. Happy to switch to icons if a slotting approach is preferred.

## Notes

- Branch off `main`; independent of open PR #54 (#44), which also touches `Connections.jsx` — a small merge may be needed depending on merge order.
- Pre-existing `App.test.js` failure (imports `./App.js`) is unrelated.