### PR TITLE
Next button in the New Connection wizard (#47)

### DIFF
--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -31,6 +31,7 @@ import { useSystemSettings } from "../contexts/SystemSettingsContext";
 import { cdfTemplate } from "../template/cdfTemplate";
 import { useAppAlert, ALERT_TYPES } from "../hooks/useAppAlert";
 import { createService, isServiceNameAvailable } from "../util/portal";
+import { isFinalStep, canAdvanceStep } from "../util/wizardSteps";
 import {
   suggestConnectionName,
   suggestDescription,
@@ -109,6 +110,12 @@ const NewConnection = ({
     btoa(string).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 
   const debounceRef = useRef();
+  const stepperRef = useRef();
+
+  const canAdvanceCurrentStep = canAdvanceStep(currentStep, {
+    canLeaveOrgUnitStep,
+    hasDataItems: selectedDimensions.length > 0,
+  });
 
   // useEffect(() => {
   //   console.log("hello render!");
@@ -372,7 +379,7 @@ const NewConnection = ({
       }}
     >
       <CalciteStepper
-        // ref={stepperRef}
+        ref={stepperRef}
         numbered
         onCalciteStepperChange={(event) => {
           console.log("stepChange", event);
@@ -564,12 +571,20 @@ const NewConnection = ({
           marginTop: "1rem",
           display: "flex",
           justifyContent: "center",
+          gap: "1rem",
           width: "100%",
           borderTop: "1px solid var(--calcite-ui-border-3)",
           paddingTop: "1rem",
         }}
       >
-        {currentStep === 4 ? (
+        <CalciteButton
+          scale="l"
+          appearance="outline"
+          onClick={() => navigate("/connections")}
+        >
+          {i18n.t("Cancel")}
+        </CalciteButton>
+        {isFinalStep(currentStep) ? (
           <CalciteButton
             iconStart="add-layer-service"
             scale="l"
@@ -582,11 +597,16 @@ const NewConnection = ({
               ? {}
               : { disabled: true })}
           >
-            Create Connection
+            {i18n.t("Create Connection")}
           </CalciteButton>
         ) : (
-          <CalciteButton scale="l" onClick={() => navigate("/connections")}>
-            Cancel
+          <CalciteButton
+            iconEnd="chevron-right"
+            scale="l"
+            onClick={() => stepperRef.current?.nextStep()}
+            {...(canAdvanceCurrentStep ? {} : { disabled: true })}
+          >
+            {i18n.t("Next")}
           </CalciteButton>
         )}
       </div>

--- a/src/util/wizardSteps.js
+++ b/src/util/wizardSteps.js
@@ -1,0 +1,37 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+// Number of steps in the New Connection wizard. The last step swaps the Next
+// control for the Create Connection action.
+export const WIZARD_STEP_COUNT = 4;
+
+export const isFinalStep = (step) => step >= WIZARD_STEP_COUNT;
+
+// Whether the author may advance past the given (1-based) wizard step. Mirrors
+// the per-step gates already enforced on the stepper items:
+// - step 1 (organisation units) consumes #42's single geometry-type flag,
+// - step 2 (data) needs at least one data item,
+// - later steps have no gate.
+export const canAdvanceStep = (
+  step,
+  { canLeaveOrgUnitStep = false, hasDataItems = false } = {}
+) => {
+  switch (step) {
+    case 1:
+      return Boolean(canLeaveOrgUnitStep);
+    case 2:
+      return Boolean(hasDataItems);
+    default:
+      return true;
+  }
+};

--- a/src/util/wizardSteps.test.js
+++ b/src/util/wizardSteps.test.js
@@ -1,0 +1,43 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+import { WIZARD_STEP_COUNT, isFinalStep, canAdvanceStep } from "./wizardSteps";
+
+describe("isFinalStep", () => {
+  it("is true only on the last step", () => {
+    expect(isFinalStep(WIZARD_STEP_COUNT)).toBe(true);
+    expect(isFinalStep(WIZARD_STEP_COUNT - 1)).toBe(false);
+    expect(isFinalStep(1)).toBe(false);
+  });
+});
+
+describe("canAdvanceStep", () => {
+  it("gates the organisation-unit step on the single geometry-type flag", () => {
+    expect(canAdvanceStep(1, { canLeaveOrgUnitStep: false })).toBe(false);
+    expect(canAdvanceStep(1, { canLeaveOrgUnitStep: true })).toBe(true);
+  });
+
+  it("gates the data step on at least one data item", () => {
+    expect(canAdvanceStep(2, { hasDataItems: false })).toBe(false);
+    expect(canAdvanceStep(2, { hasDataItems: true })).toBe(true);
+  });
+
+  it("leaves later steps ungated", () => {
+    expect(canAdvanceStep(3, {})).toBe(true);
+  });
+
+  it("defaults every gate to blocked when no flags are supplied", () => {
+    expect(canAdvanceStep(1)).toBe(false);
+    expect(canAdvanceStep(2)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #47.

## What changed
Adds a **Next** button to the New Connection wizard footer so the author can advance the steps linearly, gated on each step being valid.

- **Next** sits beside **Cancel** in the footer and advances the `CalciteStepper` (via its `nextStep()` method).
- **Next is disabled until the current step is valid.** The organisation-unit step consumes #42's single geometry-type flag (through `canLeaveOrgUnitStep`); the data step requires at least one data item. Later steps are ungated.
- On the **final step**, Next is replaced by the **Create Connection** action; **Cancel now remains available throughout** (previously it disappeared on the last step).

## Seam / tests
Per-step gating lives in a small pure seam, `src/util/wizardSteps.js` (`canAdvanceStep` / `isFinalStep`), covered by `wizardSteps.test.js`. Full suite passes; the only failing suite is the pre-existing `src/App.test.js` (imports `./App.js` while the file is `App.jsx`), unrelated to this change.

## Acceptance criteria
- [x] A Next button sits beside Cancel in the wizard footer and advances the stepper.
- [x] Next is disabled until the current step is valid; the organisation-unit step includes the single-geometry-type check.
- [x] On the final step, Next is replaced by the Keep/Create action; Cancel remains available throughout.