### PR TITLE
Preview a Connection before committing (#48)

### DIFF
--- a/src/components/PreviewPanel.jsx
+++ b/src/components/PreviewPanel.jsx
@@ -1,0 +1,107 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+import React, { useEffect, useRef } from "react";
+import i18n from "@dhis2/d2-i18n";
+import styled from "styled-components";
+import { CalciteNotice } from "@esri/calcite-components-react";
+
+import Map from "@arcgis/core/Map.js";
+import MapView from "@arcgis/core/views/MapView.js";
+import FeatureLayer from "@arcgis/core/layers/FeatureLayer.js";
+import FeatureTable from "@arcgis/core/widgets/FeatureTable.js";
+import "@arcgis/core/assets/esri/themes/light/main.css";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1;
+  min-height: 0;
+`;
+
+const MapSurface = styled.div`
+  flex: 1;
+  min-height: 260px;
+  border: 1px solid var(--calcite-ui-border-3);
+`;
+
+const TableSurface = styled.div`
+  flex: 1;
+  min-height: 220px;
+  border: 1px solid var(--calcite-ui-border-3);
+`;
+
+// Renders the real, just-created feature service: a map of the layer plus its
+// attribute table. Geometry-less Connections show the table only, with a note.
+const PreviewPanel = ({ serviceUrl, hasGeometry }) => {
+  const mapRef = useRef(null);
+  const tableRef = useRef(null);
+
+  useEffect(() => {
+    if (!serviceUrl || !tableRef.current) {
+      return undefined;
+    }
+
+    const layer = new FeatureLayer({ url: `${serviceUrl}/0` });
+
+    let view;
+    if (hasGeometry && mapRef.current) {
+      view = new MapView({
+        container: mapRef.current,
+        map: new Map({ basemap: "gray-vector", layers: [layer] }),
+      });
+      view
+        .when(() => layer.when())
+        .then(() => {
+          if (layer.fullExtent) {
+            return view.goTo(layer.fullExtent);
+          }
+          return undefined;
+        })
+        .catch(() => {});
+    }
+
+    const table = new FeatureTable({
+      layer,
+      view,
+      container: tableRef.current,
+    });
+
+    return () => {
+      table.destroy();
+      view?.destroy();
+      layer.destroy();
+    };
+  }, [serviceUrl, hasGeometry]);
+
+  return (
+    <Container>
+      {hasGeometry ? (
+        <MapSurface ref={mapRef} />
+      ) : (
+        <CalciteNotice open kind="info" icon scale="m">
+          <div slot="title">{i18n.t("Table-only preview")}</div>
+          <div slot="message">
+            {i18n.t(
+              "The selected organisation units have no geometry, so this preview shows the attribute table only with no map."
+            )}
+          </div>
+        </CalciteNotice>
+      )}
+      <TableSurface ref={tableRef} />
+    </Container>
+  );
+};
+
+export default PreviewPanel;

--- a/src/pages/Connections.jsx
+++ b/src/pages/Connections.jsx
@@ -367,6 +367,8 @@ const Connections = () => {
           {i18n.t("Remove")}
         </CalciteButton>
       </CalciteDialog>
+
+      {/* <CalcitePagination
         pageSize={10}
         startItem={0}
         totalItems={sortedData.length}

--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -24,13 +24,20 @@ import {
 
 import { DataDimension, PeriodDimension, dataTypeMap } from "@dhis2/analytics";
 import OrgUnitDimensionWrapper from "../components/OrgUnitDimensionWrapper";
+import PreviewPanel from "../components/PreviewPanel";
 import useOrgUnitGeometry from "../hooks/useOrgUnitGeometry";
 import { useAuth } from "../contexts/AuthContext";
 import { useSystemSettings } from "../contexts/SystemSettingsContext";
 
 import { cdfTemplate } from "../template/cdfTemplate";
 import { useAppAlert, ALERT_TYPES } from "../hooks/useAppAlert";
-import { createService, isServiceNameAvailable } from "../util/portal";
+import {
+  isServiceNameAvailable,
+  canPreview,
+  createPreview,
+  keepPreview,
+  deleteConnection,
+} from "../util/portal";
 import { isFinalStep, canAdvanceStep } from "../util/wizardSteps";
 import {
   suggestConnectionName,
@@ -105,6 +112,12 @@ const NewConnection = ({
   const [layerDescription, setLayerDescription] = useState("");
   const [nameEdited, setNameEdited] = useState(false);
   const [descriptionEdited, setDescriptionEdited] = useState(false);
+
+  // The just-created preview Connection (real service + item), or null while
+  // still editing. Its presence swaps the wizard for the preview view.
+  const [previewHandle, setPreviewHandle] = useState(null);
+  const [isKeeping, setIsKeeping] = useState(false);
+  const [isDiscarding, setIsDiscarding] = useState(false);
 
   const encode = (string) =>
     btoa(string).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
@@ -187,60 +200,99 @@ const NewConnection = ({
   //         <p>Final Encoded Params: {finalEncodedParams}</p>
   //       </div>
 
-  const handleCreateLayer = async () => {
-    setIsCurrentlyCreatingLayer(true);
-
-    const url = `${hostingServerProperties.url}/admin/services/createService`;
-
-    // make a copy of cdfTemplate
-    const body = { ...cdfTemplate };
-    body.f = "json";
-    body.token = userCredential.token;
-    body.service.serviceName = layerName;
-    body.service.description = layerDescription;
-    body.service.jsonProperties.customDataProviderInfo.dataProviderHost =
+  // Deep-clones the CDF template (its `service` object is shared module state)
+  // and fills in the current selection to form the createService request body.
+  const buildCreateServiceBody = () => {
+    const service = JSON.parse(JSON.stringify(cdfTemplate.service));
+    service.serviceName = layerName;
+    service.description = layerDescription;
+    service.jsonProperties.customDataProviderInfo.dataProviderHost =
       finalEncodedParams;
+    return new URLSearchParams({
+      f: "json",
+      token: userCredential.token,
+      service: JSON.stringify(service),
+    }).toString();
+  };
 
-    body.service = JSON.stringify(body.service);
-
-    const formBody = new URLSearchParams(body).toString();
-
+  // Preview creates the real feature service (ADR-0001), then the author Keeps
+  // or Discards it. Preconditions are enforced by the Preview button's gate.
+  const handlePreview = async () => {
+    setIsCurrentlyCreatingLayer(true);
     try {
-      const response = await createService(
-        hostingServerProperties.url,
-        formBody
-      );
-      console.log(response);
-      if (response.status === "success") {
-        showAlert({
-          title: i18n.t("Layer created successfully"),
-          autoClose: false,
-          message: i18n.t(
-            "Your layer has been created successfully. You can now use it in ArcGIS."
-          ),
-          type: ALERT_TYPES.SUCCESS,
-        });
-        navigate("/connections", {
-          state: { newConnectionTitle: layerName },
-        });
-      } else {
-        showAlert({
-          title: i18n.t("Error creating layer"),
-          autoClose: false,
-          message: JSON.stringify(response),
-          type: ALERT_TYPES.DANGER,
-        });
-      }
+      const handle = await createPreview({
+        portalUrl: userCredential.server,
+        hostingServerUrl: hostingServerProperties.url,
+        token: userCredential.token,
+        serviceName: layerName,
+        formBody: buildCreateServiceBody(),
+      });
+      setPreviewHandle({
+        ...handle,
+        hasGeometry: geometry.status !== "none",
+      });
     } catch (err) {
-      console.error("Error creating layer", err);
+      console.error("Error creating preview", err);
       showAlert({
-        title: i18n.t("Error creating layer"),
+        title: i18n.t("Error creating preview"),
         autoClose: false,
-        message: JSON.stringify(err),
+        message: String(err?.message || err),
         type: ALERT_TYPES.DANGER,
       });
     } finally {
       setIsCurrentlyCreatingLayer(false);
+    }
+  };
+
+  // Keep commits the previewed Connection: no recreation, just strip the
+  // preview tag (best-effort) and go to the Connections list.
+  const handleKeep = async () => {
+    if (!previewHandle) return;
+    setIsKeeping(true);
+    try {
+      await keepPreview({
+        portalUrl: userCredential.server,
+        owner: previewHandle.owner,
+        itemId: previewHandle.itemId,
+        token: userCredential.token,
+        typeKeywords: previewHandle.typeKeywords,
+      });
+    } catch (err) {
+      // A failed untag must never block the commit; the tag just lingers.
+      console.warn("Could not remove the preview tag on keep", err);
+    } finally {
+      setIsKeeping(false);
+      navigate("/connections", {
+        state: { newConnectionTitle: previewHandle.serviceName },
+      });
+    }
+  };
+
+  // Discard deletes both artifacts (portal item + CDF service) and returns to
+  // editing the same selection.
+  const handleDiscard = async () => {
+    if (!previewHandle) return;
+    setIsDiscarding(true);
+    try {
+      await deleteConnection({
+        portalUrl: userCredential.server,
+        hostingServerUrl: hostingServerProperties.url,
+        owner: previewHandle.owner,
+        itemId: previewHandle.itemId,
+        serviceName: previewHandle.serviceName,
+        token: userCredential.token,
+      });
+      setPreviewHandle(null);
+    } catch (err) {
+      console.error("Error discarding preview", err);
+      showAlert({
+        title: i18n.t("Error discarding preview"),
+        autoClose: false,
+        message: String(err?.message || err),
+        type: ALERT_TYPES.DANGER,
+      });
+    } finally {
+      setIsDiscarding(false);
     }
   };
 
@@ -380,7 +432,68 @@ const NewConnection = ({
         justifyContent: "space-between",
       }}
     >
-      <CalciteStepper
+      {previewHandle ? (
+        <>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              flex: 1,
+              minHeight: 0,
+              gap: "1rem",
+            }}
+          >
+            <h2 style={{ fontSize: "1.5rem", fontWeight: 600, margin: 0 }}>
+              {i18n.t("Preview of {{name}}", {
+                name: previewHandle.serviceName,
+              })}
+            </h2>
+            <Description>
+              {i18n.t(
+                "This preview is the real Connection. Keep it to finish, or Discard to delete it and continue editing."
+              )}
+            </Description>
+            <PreviewPanel
+              serviceUrl={previewHandle.serviceUrl}
+              hasGeometry={previewHandle.hasGeometry}
+            />
+          </div>
+          <div
+            style={{
+              marginTop: "1rem",
+              display: "flex",
+              justifyContent: "center",
+              gap: "1rem",
+              width: "100%",
+              borderTop: "1px solid var(--calcite-ui-border-3)",
+              paddingTop: "1rem",
+            }}
+          >
+            <CalciteButton
+              scale="l"
+              appearance="outline"
+              kind="danger"
+              iconStart="trash"
+              loading={isDiscarding}
+              {...(isKeeping ? { disabled: true } : {})}
+              onClick={handleDiscard}
+            >
+              {i18n.t("Discard")}
+            </CalciteButton>
+            <StyledCreateCalciteButton
+              scale="l"
+              iconStart="check"
+              loading={isKeeping}
+              {...(isDiscarding ? { disabled: true } : {})}
+              onClick={handleKeep}
+            >
+              {i18n.t("Keep")}
+            </StyledCreateCalciteButton>
+          </div>
+        </>
+      ) : (
+        <>
+          <CalciteStepper
         ref={stepperRef}
         numbered
         onCalciteStepperChange={(event) => {
@@ -588,18 +701,20 @@ const NewConnection = ({
         </CalciteButton>
         {isFinalStep(currentStep) ? (
           <CalciteButton
-            iconStart="add-layer-service"
+            iconStart="map"
             scale="l"
             loading={isCurrentlyCreatingLayer || isCheckingName}
-            onClick={handleCreateLayer}
-            {...(isLayerNameAvailable &&
-            isLayerNameValid &&
-            !isCheckingName &&
-            geometry.valid
+            onClick={handlePreview}
+            {...(canPreview({
+              isLayerNameValid,
+              isLayerNameAvailable,
+              isCheckingName,
+              geometryValid: geometry.valid,
+            })
               ? {}
               : { disabled: true })}
           >
-            {i18n.t("Create Connection")}
+            {i18n.t("Preview")}
           </CalciteButton>
         ) : (
           <CalciteButton
@@ -612,6 +727,8 @@ const NewConnection = ({
           </CalciteButton>
         )}
       </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/util/portal.js
+++ b/src/util/portal.js
@@ -158,3 +158,117 @@ export async function deleteConnection({
   const item = await deletePortalItem(portalUrl, owner, itemId, token);
   return { service, item };
 }
+
+// typeKeyword stamped on Preview-created services so previews abandoned via a
+// hard close stay discoverable (and cleanable) as orphans (ADR-0001).
+export const PREVIEW_TYPE_KEYWORD = "dhis2Preview";
+
+// Pure precondition gate for Preview. Per ADR-0001 Preview is the real create,
+// so the name must be valid + available and the single geometry-type check
+// (issue #42) must pass before it runs.
+export const canPreview = ({
+  isLayerNameValid = false,
+  isLayerNameAvailable = false,
+  isCheckingName = true,
+  geometryValid = false,
+} = {}) =>
+  Boolean(
+    isLayerNameValid && isLayerNameAvailable && !isCheckingName && geometryValid
+  );
+
+// Full replace of an item's typeKeywords via the portal item update endpoint.
+export async function updatePortalItemTypeKeywords(
+  portalUrl,
+  owner,
+  itemId,
+  typeKeywords,
+  token
+) {
+  const url = `${portalUrl}/sharing/rest/content/users/${owner}/items/${itemId}/update`;
+  const body = new URLSearchParams({
+    f: "json",
+    token,
+    typeKeywords: (typeKeywords || []).join(","),
+  }).toString();
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const data = await response.json();
+  if (data?.error) {
+    throw new Error(data.error.message || "Failed to update the portal item.");
+  }
+  return data;
+}
+
+// Resolves the portal item a just-created service belongs to. The ArcGIS search
+// index lags a fresh create, so poll the Connections list until it appears.
+async function resolvePreviewItem(portalUrl, serviceName, token) {
+  const matches = (service) =>
+    service.title === serviceName || service.name === serviceName;
+  const results = await pollForServices({
+    server: portalUrl,
+    token,
+    predicate: matches,
+  });
+  return results.find(matches);
+}
+
+// Preview lifecycle — create side. Creates the real feature service, resolves
+// its portal item, stamps it with the preview typeKeyword, and returns the
+// handle used to render, Keep, or Discard it. Collaborators are injectable so
+// the orchestration is testable through this seam.
+export async function createPreview({
+  portalUrl,
+  hostingServerUrl,
+  token,
+  serviceName,
+  formBody,
+  create = createService,
+  resolveItem = resolvePreviewItem,
+  updateTypeKeywords = updatePortalItemTypeKeywords,
+}) {
+  const response = await create(hostingServerUrl, formBody);
+  if (response?.status !== "success") {
+    throw new Error(
+      (Array.isArray(response?.messages) && response.messages.join("; ")) ||
+        "Failed to create the preview service."
+    );
+  }
+
+  const item = await resolveItem(portalUrl, serviceName, token);
+  if (!item) {
+    throw new Error(
+      "The preview service was created but its portal item could not be found."
+    );
+  }
+
+  const typeKeywords = Array.from(
+    new Set([...(item.typeKeywords || []), PREVIEW_TYPE_KEYWORD])
+  );
+  await updateTypeKeywords(portalUrl, item.owner, item.id, typeKeywords, token);
+
+  return {
+    itemId: item.id,
+    owner: item.owner,
+    serviceName,
+    serviceUrl: item.url,
+    typeKeywords,
+  };
+}
+
+// Preview lifecycle — Keep side. Commit strips the preview typeKeyword so a
+// later orphan sweep can't mistake a kept Connection for an abandoned preview.
+export async function keepPreview({
+  portalUrl,
+  owner,
+  itemId,
+  token,
+  typeKeywords = [],
+  updateTypeKeywords = updatePortalItemTypeKeywords,
+}) {
+  const remaining = typeKeywords.filter((k) => k !== PREVIEW_TYPE_KEYWORD);
+  await updateTypeKeywords(portalUrl, owner, itemId, remaining, token);
+  return remaining;
+}

--- a/src/util/portal.test.js
+++ b/src/util/portal.test.js
@@ -15,7 +15,15 @@ limitations under the License.*/
 // at module load, so stub it out to keep these seam tests focused.
 jest.mock("@arcgis/core/request.js", () => ({ default: jest.fn() }));
 
-import { deleteConnection, pollForServices } from "./portal";
+import {
+  deleteConnection,
+  pollForServices,
+  canPreview,
+  createPreview,
+  keepPreview,
+  updatePortalItemTypeKeywords,
+  PREVIEW_TYPE_KEYWORD,
+} from "./portal";
 
 const byTitle = (title) => (service) => service.title === title;
 const noWait = jest.fn().mockResolvedValue(undefined);
@@ -174,5 +182,195 @@ describe("deleteConnection", () => {
 
     await expect(deleteConnection(baseArgs)).rejects.toThrow("no permission");
     expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("canPreview", () => {
+  const ready = {
+    isLayerNameValid: true,
+    isLayerNameAvailable: true,
+    isCheckingName: false,
+    geometryValid: true,
+  };
+
+  it("allows Preview only when every precondition is met", () => {
+    expect(canPreview(ready)).toBe(true);
+  });
+
+  it("blocks Preview when the layer name is invalid or unavailable", () => {
+    expect(canPreview({ ...ready, isLayerNameValid: false })).toBe(false);
+    expect(canPreview({ ...ready, isLayerNameAvailable: false })).toBe(false);
+  });
+
+  it("blocks Preview while the name check is still running", () => {
+    expect(canPreview({ ...ready, isCheckingName: true })).toBe(false);
+  });
+
+  it("blocks Preview when the single geometry-type check fails", () => {
+    expect(canPreview({ ...ready, geometryValid: false })).toBe(false);
+  });
+
+  it("defaults to blocked when no state is supplied", () => {
+    expect(canPreview()).toBe(false);
+  });
+});
+
+describe("updatePortalItemTypeKeywords", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("POSTs the joined typeKeywords with f=json and the token", async () => {
+    global.fetch.mockReturnValueOnce(okJson({ success: true, id: "abc123" }));
+
+    await updatePortalItemTypeKeywords(
+      "https://example.com/portal",
+      "jdoe",
+      "abc123",
+      ["providerCustomData", PREVIEW_TYPE_KEYWORD],
+      "t0ken"
+    );
+
+    const [url, options] = global.fetch.mock.calls[0];
+    expect(url).toBe(
+      "https://example.com/portal/sharing/rest/content/users/jdoe/items/abc123/update"
+    );
+    const params = new URLSearchParams(options.body);
+    expect(params.get("f")).toBe("json");
+    expect(params.get("token")).toBe("t0ken");
+    expect(params.get("typeKeywords")).toBe(
+      `providerCustomData,${PREVIEW_TYPE_KEYWORD}`
+    );
+  });
+
+  it("throws when the update reports an error", async () => {
+    global.fetch.mockReturnValueOnce(okJson({ error: { message: "denied" } }));
+
+    await expect(
+      updatePortalItemTypeKeywords("p", "o", "i", [], "t")
+    ).rejects.toThrow("denied");
+  });
+});
+
+describe("createPreview", () => {
+  const previewArgs = {
+    portalUrl: "https://example.com/portal",
+    hostingServerUrl: "https://example.com/server",
+    token: "t0ken",
+    serviceName: "my_connection",
+    formBody: "f=json&service=%7B%7D",
+  };
+
+  it("tags the resolved item as a preview and returns its handle", async () => {
+    const create = jest.fn().mockResolvedValue({ status: "success" });
+    const resolveItem = jest.fn().mockResolvedValue({
+      id: "abc123",
+      owner: "jdoe",
+      url: "https://example.com/server/rest/services/my_connection/FeatureServer",
+      typeKeywords: ["providerCustomData"],
+    });
+    const updateTypeKeywords = jest.fn().mockResolvedValue({ success: true });
+
+    const handle = await createPreview({
+      ...previewArgs,
+      create,
+      resolveItem,
+      updateTypeKeywords,
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      previewArgs.hostingServerUrl,
+      previewArgs.formBody
+    );
+    expect(updateTypeKeywords).toHaveBeenCalledWith(
+      previewArgs.portalUrl,
+      "jdoe",
+      "abc123",
+      ["providerCustomData", PREVIEW_TYPE_KEYWORD],
+      previewArgs.token
+    );
+    expect(handle).toEqual({
+      itemId: "abc123",
+      owner: "jdoe",
+      serviceName: "my_connection",
+      serviceUrl:
+        "https://example.com/server/rest/services/my_connection/FeatureServer",
+      typeKeywords: ["providerCustomData", PREVIEW_TYPE_KEYWORD],
+    });
+  });
+
+  it("does not duplicate the preview keyword when it is already present", async () => {
+    const create = jest.fn().mockResolvedValue({ status: "success" });
+    const resolveItem = jest.fn().mockResolvedValue({
+      id: "abc123",
+      owner: "jdoe",
+      url: "u",
+      typeKeywords: ["providerCustomData", PREVIEW_TYPE_KEYWORD],
+    });
+    const updateTypeKeywords = jest.fn().mockResolvedValue({});
+
+    const handle = await createPreview({
+      ...previewArgs,
+      create,
+      resolveItem,
+      updateTypeKeywords,
+    });
+
+    expect(handle.typeKeywords).toEqual([
+      "providerCustomData",
+      PREVIEW_TYPE_KEYWORD,
+    ]);
+  });
+
+  it("throws and never resolves or tags when the service create fails", async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValue({ status: "error", messages: ["boom"] });
+    const resolveItem = jest.fn();
+    const updateTypeKeywords = jest.fn();
+
+    await expect(
+      createPreview({ ...previewArgs, create, resolveItem, updateTypeKeywords })
+    ).rejects.toThrow("boom");
+    expect(resolveItem).not.toHaveBeenCalled();
+    expect(updateTypeKeywords).not.toHaveBeenCalled();
+  });
+
+  it("throws when the created service's item cannot be resolved", async () => {
+    const create = jest.fn().mockResolvedValue({ status: "success" });
+    const resolveItem = jest.fn().mockResolvedValue(undefined);
+    const updateTypeKeywords = jest.fn();
+
+    await expect(
+      createPreview({ ...previewArgs, create, resolveItem, updateTypeKeywords })
+    ).rejects.toThrow(/could not be found/);
+    expect(updateTypeKeywords).not.toHaveBeenCalled();
+  });
+});
+
+describe("keepPreview", () => {
+  it("strips only the preview keyword and persists the remainder", async () => {
+    const updateTypeKeywords = jest.fn().mockResolvedValue({ success: true });
+
+    const remaining = await keepPreview({
+      portalUrl: "p",
+      owner: "jdoe",
+      itemId: "abc123",
+      token: "t",
+      typeKeywords: ["providerCustomData", PREVIEW_TYPE_KEYWORD],
+      updateTypeKeywords,
+    });
+
+    expect(remaining).toEqual(["providerCustomData"]);
+    expect(updateTypeKeywords).toHaveBeenCalledWith(
+      "p",
+      "jdoe",
+      "abc123",
+      ["providerCustomData"],
+      "t"
+    );
   });
 });


### PR DESCRIPTION
Closes #48.

## What changed

Per **ADR-0001**, Preview creates the _real_ feature service and shows its map + attribute table before the author commits; they then **Keep** it (commit) or **Discard** it (delete both artifacts). The Summary step's green **Create Connection** button is replaced by **Preview** (Keep is the commit — there is no separate Create step).

### Lifecycle seam (tested through `portal.js`)

- `canPreview(...)` — pure precondition gate (name valid + available, name check idle, single geometry-type check from #42).
- `createPreview(...)` — creates the real service, resolves its portal item (polling past ArcGIS search-index lag), stamps it with the `dhis2Preview` typeKeyword so abandoned previews are discoverable, and returns a handle.
- `keepPreview(...)` — commit strips the preview typeKeyword (best-effort, never blocks the commit) so an orphan sweep can't reclaim a kept Connection.
- `updatePortalItemTypeKeywords(...)` — item typeKeywords update.
- Discard reuses the existing `deleteConnection` (#45).

### UI

- New `PreviewPanel` renders the layer with `@arcgis/core` (`MapView` + `FeatureLayer` + `FeatureTable`), no new dependencies. Geometry-less selections show the **attribute table only, with a note and no map**.
- `NewConnection` gains the Preview → Keep/Discard flow; Keep navigates to Connections without recreating; Discard deletes both artifacts and returns to editing.

## Drive-by build fix (first commit)

`main` did not build: the Connections page's commented-out `CalcitePagination` block had lost its opening `{/*` marker, leaving a dangling `*/}` (vite/babel parse error). The first commit restores the comment opener. It is independent of #48 and safe to fast-track / cherry-pick.

## Tests & build

- Full suite green: **58 passing**; the only failing suite is the pre-existing `src/App.test.js` (imports `./App.js` while the file is `App.jsx`), unrelated.
- `d2-app-scripts build` succeeds (ArcGIS map modules + CSS bundle correctly).
- The `@arcgis/core` map/table rendering is not unit-tested, consistent with the repo convention of mocking `@arcgis/core` out of tests.

## Acceptance criteria

- [x] Preview creates the real feature service and shows a map + attribute table.
- [x] Geometry-less selections show the attribute table only, with a note and no map.
- [x] Keep commits (navigates to Connections) without recreating anything.
- [x] Discard deletes both the portal item and the CDF service via `deleteConnection` and returns to editing.
- [x] Name validity/availability and the single geometry-type check are enforced before Preview runs.
- [x] Preview-created services are tagged (`dhis2Preview`) so orphans are discoverable.
- [x] Preview lifecycle orchestration is tested through the `portal.js` seam.
