### PR TITLE
Post-upload QA fixes: Redirect URL, wizard Next/Preview, geometry pre-check, 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dhis2-arcgis-app",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/hooks/useOrgUnitGeometry.js
+++ b/src/hooks/useOrgUnitGeometry.js
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.*/
 
+import { useEffect } from "react";
 import { useDataQuery } from "@dhis2/app-runtime";
 
 import { evaluateGeometrySelection } from "../util/geometry";
@@ -26,17 +27,27 @@ const GEO_FEATURES_QUERY = {
 // geoFeatures, exposing the single block/warn/allow flag the wizard consumes.
 const useOrgUnitGeometry = (selectedOrgUnits = []) => {
   const ids = selectedOrgUnits.map((orgUnit) => orgUnit.id);
+  const ou = ids.join(";");
   const enabled = ids.length > 0;
 
-  const { loading, error, data } = useDataQuery(GEO_FEATURES_QUERY, {
-    lazy: !enabled,
-    variables: { ou: ids.join(";") },
-  });
+  const { called, loading, error, data, refetch } = useDataQuery(
+    GEO_FEATURES_QUERY,
+    { lazy: true, variables: { ou } }
+  );
 
-  const geoFeatures = data?.geoFeatures ?? [];
+  // The selection isn't known at mount and changes as the user edits it, so a
+  // lazy query that auto-fires only on mount would never run. Fetch on every
+  // selection change instead.
+  useEffect(() => {
+    if (enabled) {
+      refetch({ ou });
+    }
+  }, [ou, enabled, refetch]);
+
+  const geoFeatures = enabled ? data?.geoFeatures ?? [] : [];
 
   return {
-    loading: enabled && loading,
+    loading: enabled && (!called || loading),
     error,
     ...evaluateGeometrySelection({ geoFeatures, selectedCount: ids.length }),
   };

--- a/src/hooks/useOrgUnitGeometry.test.js
+++ b/src/hooks/useOrgUnitGeometry.test.js
@@ -87,3 +87,48 @@ it("allows a table-only selection when no unit has geometry", async () => {
   const text = await evaluate([], sel("a", "b"));
   expect(text).toBe("true|none|");
 });
+
+// The real app mounts this hook before any org unit is chosen, then the
+// selection arrives. Geometry must be fetched on that transition, not only when
+// the selection is present at mount.
+const evaluateAfterMount = async (geoFeatures, selected) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  const render = (sel) =>
+    act(async () => {
+      ReactDOM.render(
+        <CustomDataProvider data={{ geoFeatures }}>
+          <Probe selected={sel} />
+        </CustomDataProvider>,
+        container
+      );
+    });
+
+  // Mount with an empty selection (lazy), then supply the real selection.
+  await render([]);
+  await render(selected);
+
+  const read = () => container.querySelector('[data-testid="out"]').textContent;
+  for (let i = 0; i < 50 && read() === "loading"; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  const text = read();
+  act(() => {
+    ReactDOM.unmountComponentAtNode(container);
+  });
+  container.remove();
+  return text;
+};
+
+it("fetches geometry when the selection arrives after mount", async () => {
+  const text = await evaluateAfterMount(
+    [polygon("a"), polygon("b")],
+    sel("a", "b")
+  );
+  expect(text).toBe("true|ok|Polygon");
+});

--- a/src/pages/Configure.jsx
+++ b/src/pages/Configure.jsx
@@ -16,7 +16,6 @@ import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 
 import i18n from "@dhis2/d2-i18n";
-import { useConfig } from "@dhis2/app-runtime";
 
 import {
   CalciteButton,
@@ -84,8 +83,6 @@ const Configure = () => {
   const { settings, updateSetting, isLoadingSettings } = useSystemSettings();
   const { showAlert } = useAppAlert();
   const { setOAuthConfig, setUserCredential, signOut } = useAuth();
-  const { baseUrl } = useConfig();
-  // console.log(baseUrl);
 
   const [clientId, setClientId] = useState(settings?.arcgisConfig?.clientId);
   const [portalUrl, setPortalUrl] = useState(settings?.arcgisConfig?.portalUrl);
@@ -153,13 +150,13 @@ const Configure = () => {
       <StyledCalciteInputText
         prefixText={i18n.t("Redirect URL")}
         readOnly
-        value={baseUrl}
+        value={window.location.origin}
       >
         <StyledCalciteButtonCopyToClipboard
           slot="action"
           iconStart={redirectUrlIcon}
           onClick={() => {
-            navigator.clipboard.writeText(baseUrl);
+            navigator.clipboard.writeText(window.location.origin);
             setRedirectUrlIcon("check");
             setTimeout(() => {
               setRedirectUrlIcon("copy-to-clipboard");

--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -38,7 +38,11 @@ import {
   keepPreview,
   deleteConnection,
 } from "../util/portal";
-import { isFinalStep, canAdvanceStep } from "../util/wizardSteps";
+import {
+  isFinalStep,
+  canAdvanceStep,
+  WIZARD_STEP_COUNT,
+} from "../util/wizardSteps";
 import {
   suggestConnectionName,
   suggestDescription,
@@ -720,7 +724,11 @@ const NewConnection = ({
           <CalciteButton
             iconEnd="chevron-right"
             scale="l"
-            onClick={() => stepperRef.current?.nextStep()}
+            onClick={() => {
+              stepperRef.current?.nextStep();
+              // nextStep() emits no calciteStepperChange, so advance our state too.
+              setCurrentStep((step) => Math.min(step + 1, WIZARD_STEP_COUNT));
+            }}
             {...(canAdvanceCurrentStep ? {} : { disabled: true })}
           >
             {i18n.t("Next")}


### PR DESCRIPTION
Post-upload QA fixes from testing the `1.0.0` build. Four independent fixes plus the version bump; each is small and testable.

## Changes

### `chore` — version bump to `1.0.0`
So the uploaded bundle registers as a new app version.

### #1 — Redirect URL shows the DHIS2 URL again
`#37` replaced `window.location.origin` with `baseUrl` on the Configure page. In a production build `baseUrl` is the relative `../../..`, so the Redirect URL field showed that instead of the DHIS2 URL. Reverted to `window.location.origin` for both the field value and the clipboard copy; removed the now-unused `useConfig` import.

### #2 + #4 — wizard step state syncs when advancing via Next (one root cause)
Calcite's `stepper.nextStep()` emits only the internal item-change event, **not** the public `calciteStepperChange`, so clicking Next advanced the visual stepper without updating React `currentStep`. On the Summary step `currentStep` stayed at 3, so the footer showed **Next** instead of **Preview** (#4) and the suggested name/description effect (gated on the final step) never ran, leaving both fields blank (#2). Fixed by advancing `currentStep` in the Next click handler.

### #3a — geometry pre-check fetches `geoFeatures` when the selection arrives
`useOrgUnitGeometry` created its query with `lazy: !enabled` and relied on it auto-firing when the selection arrived later — it never did, so no `geoFeatures` request was sent, `data` stayed undefined, and `evaluateGeometrySelection([])` reported `status: "none"` → the wizard wrongly showed a **table-only** Connection for known-polygon org units (and no `geoFeatures` request appeared in the Network tab). Switched to an explicit `refetch` on every selection change, treating "enabled but not yet fetched" as loading. Added a test for the mount-empty-then-select transition the existing tests missed.

## Tests
Full suite green: **59 passing**; the only failing suite is the pre-existing `src/App.test.js` (imports `./App.js` while the file is `App.jsx`), unrelated. `d2-app-scripts build` succeeds.

## Follow-up (not in this PR)
Testing surfaced that step 1's org-unit selector is confusing for level/group selections (a level can silently resolve to just the parent) and that the tree isn't scoped to the user. That redesign was scoped via a grilling session and is tracked in #58 (with #59 as a deferred auto-split follow-up). #3b (no polygons in the created service) is CDF-side and tracked for live verification.
