### PR TITLE
Bring #58 org-unit selection + UI fixes to main (recover mis-targeted #61)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,3 +17,12 @@ The Custom Data Feed service registered on the hosting server (via `admin/servic
 **Preview**:
 Creating a Connection's real feature service and inspecting it (map + attribute table) before committing. The user then keeps it or discards it; discarding deletes the just-created portal item and CDF service.
 _Avoid_: Draft, Trial
+
+**Resolves to**:
+The concrete set of organisation units a selection expands to. A level or group selection (e.g. "District", "Hospitals") plus a boundary expands to many units; step 1 reports how many it resolves to so a mismatch is visible rather than silent.
+
+**Mappable units**:
+The organisation units in a selection that have geometry (points or polygons) and will appear on the map. Units without geometry become table-only rows. The resolves-to count is of mappable units.
+
+**Boundary**:
+The ancestor organisation unit(s) a level/group selection is evaluated under ("districts _under_ this boundary"). Defaults to the signed-in user's accessible roots when none is explicitly chosen.

--- a/docs/adr/0002-orgunit-selection.md
+++ b/docs/adr/0002-orgunit-selection.md
@@ -1,0 +1,18 @@
+# Org-unit selection: user-scoped roots, level/group bulk-select, and a resolves-to preview
+
+Step 1's org-unit selector uses the DHIS2 `OrgUnitDimension`, whose "Select a level" (and "Select a group") emits an `ou` dimension of the form `<boundary>;LEVEL-<uid>`. DHIS2 analytics reads that as *"org units at that level under the boundary."* When the checked boundary is not a higher ancestor of the chosen level, the selection silently resolves to just the boundary — an author picks "districts" and gets one country-level row with no explanation. Explicit tree selection works but is tedious for bulk selections. Separately, the tree roots were not scoped to the signed-in user.
+
+We keep the `OrgUnitDimension` (levels and groups are genuinely useful for bulk selection) and **extend** it rather than rebuild:
+
+- **Levels/groups are reframed as user-scoped bulk selects.** When a level or group is chosen with nothing checked in the tree, the user's own root org units are injected as the boundary, so "District" means "all districts I can see." A checked parent narrows it.
+- **Selection is made visible.** Step 1 shows what the current selection **resolves to** — the count of mappable org units and their geometry type — so a level/boundary mismatch is obvious instead of silent. The resolution is derived from the `geoFeatures` call the wizard already makes; the #48 Preview remains the authoritative exact view.
+- **The tree is scoped to the user.** Roots come from the signed-in user's `dataViewOrganisationUnits`, falling back to `organisationUnits`.
+
+The single source of truth is a pure `resolveOuDimension(rawSelection, userRoots)` that produces the `ou` id list feeding both the `geoFeatures` pre-check and the created service's `dataProviderHost`.
+
+## Consequences
+
+- A level/group selected with no explicit boundary resolves against the user's roots, not the whole instance or an undefined default.
+- The `geoFeatures` pre-check and the `dataProviderHost` are always built from the same resolved `ou`, so what the preview reports and what the service serves cannot diverge.
+- The single-geometry-type rule (ADR-0001, issue #42) stays a **hard block**; the resolves-to panel makes a mixed-geometry selection visible and actionable rather than a silent stop. Auto-splitting a mixed selection into multiple Connections is deferred (issue #59).
+- The resolves-to count is of **mappable** units (those with geometry); geometry-less units are surfaced separately as table-only. An exact total including geometry-less units is deferred unless the mappable count proves insufficient.

--- a/src/hooks/useOrgUnitGeometry.js
+++ b/src/hooks/useOrgUnitGeometry.js
@@ -23,12 +23,11 @@ const GEO_FEATURES_QUERY = {
   },
 };
 
-// Resolves the geometry validity of the current org-unit selection from DHIS2
+// Resolves the geometry validity of a resolved `ou` selection from DHIS2
 // geoFeatures, exposing the single block/warn/allow flag the wizard consumes.
-const useOrgUnitGeometry = (selectedOrgUnits = []) => {
-  const ids = selectedOrgUnits.map((orgUnit) => orgUnit.id);
-  const ou = ids.join(";");
-  const enabled = ids.length > 0;
+const useOrgUnitGeometry = (ouIds = []) => {
+  const ou = ouIds.join(";");
+  const enabled = ouIds.length > 0;
 
   const { called, loading, error, data, refetch } = useDataQuery(
     GEO_FEATURES_QUERY,
@@ -49,7 +48,7 @@ const useOrgUnitGeometry = (selectedOrgUnits = []) => {
   return {
     loading: enabled && (!called || loading),
     error,
-    ...evaluateGeometrySelection({ geoFeatures, selectedCount: ids.length }),
+    ...evaluateGeometrySelection({ geoFeatures, selectedCount: ouIds.length }),
   };
 };
 

--- a/src/hooks/useOrgUnitGeometry.js
+++ b/src/hooks/useOrgUnitGeometry.js
@@ -48,6 +48,7 @@ const useOrgUnitGeometry = (ouIds = []) => {
   return {
     loading: enabled && (!called || loading),
     error,
+    mappableCount: geoFeatures.length,
     ...evaluateGeometrySelection({ geoFeatures, selectedCount: ouIds.length }),
   };
 };

--- a/src/hooks/useOrgUnitGeometry.test.js
+++ b/src/hooks/useOrgUnitGeometry.test.js
@@ -63,7 +63,7 @@ const evaluate = async (geoFeatures, selected) => {
 
 const point = (id) => ({ id, ty: 1 });
 const polygon = (id) => ({ id, ty: 2 });
-const sel = (...ids) => ids.map((id) => ({ id }));
+const sel = (...ids) => ids;
 
 it("blocks a mixed selection through the provider seam", async () => {
   const text = await evaluate(

--- a/src/hooks/useOrgUnitRoots.js
+++ b/src/hooks/useOrgUnitRoots.js
@@ -13,14 +13,19 @@ limitations under the License.*/
 
 import { useDataQuery } from "@dhis2/app-runtime";
 
-// Fetches the root org units associated with the current user with fallback to data capture org units
+import { pickUserRoots } from "../util/orgUnits";
+
+// Fetches the signed-in user's root org units: their analytics data-view org
+// units, falling back to their data-capture org units.
 const ORG_UNIT_ROOTS_QUERY = {
-  roots: {
-    resource: "organisationUnits",
-    params: () => ({
-      fields: ["id", "displayName~rename(name)", "path"],
-      userDataViewFallback: true,
-    }),
+  me: {
+    resource: "me",
+    params: {
+      fields: [
+        "organisationUnits[id,displayName~rename(name),path]",
+        "dataViewOrganisationUnits[id,displayName~rename(name),path]",
+      ],
+    },
   },
 };
 
@@ -28,7 +33,7 @@ const useOrgUnitRoots = () => {
   const { loading, error, data } = useDataQuery(ORG_UNIT_ROOTS_QUERY);
 
   return {
-    roots: data?.roots?.organisationUnits,
+    roots: data ? pickUserRoots(data.me) : undefined,
     error,
     loading,
   };

--- a/src/pages/Connections.jsx
+++ b/src/pages/Connections.jsx
@@ -350,7 +350,7 @@ const Connections = () => {
           )}
         </div>
         <CalciteButton
-          slot="secondary"
+          slot="footer-start"
           appearance="outline"
           disabled={deletingId !== null}
           onClick={() => setConnectionToDelete(null)}
@@ -358,7 +358,7 @@ const Connections = () => {
           {i18n.t("Cancel")}
         </CalciteButton>
         <CalciteButton
-          slot="primary"
+          slot="footer-end"
           kind="danger"
           iconStart="trash"
           loading={deletingId !== null}

--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.*/
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import i18n from "@dhis2/d2-i18n";
 
 import {
@@ -26,6 +26,8 @@ import { DataDimension, PeriodDimension, dataTypeMap } from "@dhis2/analytics";
 import OrgUnitDimensionWrapper from "../components/OrgUnitDimensionWrapper";
 import PreviewPanel from "../components/PreviewPanel";
 import useOrgUnitGeometry from "../hooks/useOrgUnitGeometry";
+import useOrgUnitRoots from "../hooks/useOrgUnitRoots";
+import { resolveOuDimension } from "../util/orgUnits";
 import { useAuth } from "../contexts/AuthContext";
 import { useSystemSettings } from "../contexts/SystemSettingsContext";
 
@@ -96,8 +98,17 @@ const NewConnection = ({
   const [selectedDimensions, setSelectedDimensions] = useState([]);
   const [selectedPeriods, setSelectedPeriods] = useState([]);
 
+  const { roots } = useOrgUnitRoots();
+
+  // Levels/groups resolve against the user's roots; this resolved ou is the
+  // single source for both the geometry pre-check and the created service (#58).
+  const resolvedOuIds = useMemo(
+    () => resolveOuDimension(selectedOrgUnits, roots),
+    [selectedOrgUnits, roots]
+  );
+
   // Single geometry-type validity for the org-unit step (issue #42).
-  const geometry = useOrgUnitGeometry(selectedOrgUnits);
+  const geometry = useOrgUnitGeometry(resolvedOuIds);
   const canLeaveOrgUnitStep =
     selectedOrgUnits.length > 0 && !geometry.loading && geometry.valid;
 
@@ -148,7 +159,7 @@ const NewConnection = ({
   useEffect(() => {
     const dimensions = selectedDimensions.map((dimension) => dimension.id);
     const periods = selectedPeriods.map((period) => period.id);
-    const orgUnits = selectedOrgUnits.map((orgUnit) => orgUnit.id);
+    const orgUnits = resolvedOuIds;
 
     const finalStringParams = `dimension=dx:${dimensions.join(
       ";"
@@ -184,7 +195,7 @@ const NewConnection = ({
     setDebugInfo(newDebugInfo);
 
     updateDebugInfo(newDebugInfo);
-  }, [selectedOrgUnits, selectedDimensions, selectedPeriods]);
+  }, [resolvedOuIds, selectedOrgUnits, selectedDimensions, selectedPeriods]);
 
   // <div>
   //         <p>Selected Org Units: {JSON.stringify(selectedOrgUnits)}</p>

--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -508,6 +508,7 @@ const NewConnection = ({
         </>
       ) : (
         <>
+          <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
           <CalciteStepper
         ref={stepperRef}
         numbered
@@ -719,9 +720,11 @@ const NewConnection = ({
           </div>
         </CalciteStepperItem>
       </CalciteStepper>
+          </div>
       <div
         style={{
           marginTop: "1rem",
+          flexShrink: 0,
           display: "flex",
           justifyContent: "center",
           gap: "1rem",

--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -537,6 +537,29 @@ const NewConnection = ({
             <br />
           </Description>
           <OrgUnitDimensionWrapper onChange={setSelectedOrgUnits} />
+          {selectedOrgUnits.length > 0 && (
+            <div
+              style={{
+                margin: "0.75rem 0",
+                fontSize: "15px",
+                fontWeight: 500,
+              }}
+            >
+              {geometry.loading
+                ? i18n.t("Checking your selection…")
+                : geometry.mappableCount > 0
+                ? i18n.t(
+                    "Resolves to {{count}} mappable organisation units • geometry: {{types}}",
+                    {
+                      count: geometry.mappableCount,
+                      types: geometry.geometryTypes.join(" and "),
+                    }
+                  )
+                : i18n.t(
+                    "Resolves to a table-only Connection (no mapped organisation units)."
+                  )}
+            </div>
+          )}
           {selectedOrgUnits.length > 0 && geometry.status === "mixed" && (
             <CalciteNotice open kind="danger" icon scale="m">
               <div slot="title">{i18n.t("Mixed geometry types")}</div>

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -18,3 +18,30 @@ export const pickUserRoots = (me = {}) => {
   const dataCapture = me?.organisationUnits ?? [];
   return dataView.length ? dataView : dataCapture;
 };
+
+const LEVEL_PREFIX = "LEVEL-";
+const OU_GROUP_PREFIX = "OU_GROUP-";
+
+const isLevel = (id) => id.startsWith(LEVEL_PREFIX);
+const isGroup = (id) => id.startsWith(OU_GROUP_PREFIX);
+// An explicit org unit or dynamic keyword (e.g. USER_ORGUNIT) can serve as the
+// boundary a level or group is evaluated under; a level/group id cannot.
+const isBoundary = (id) => !isLevel(id) && !isGroup(id);
+
+// Turns the raw org-unit selection into the resolved `ou` dimension ids used by
+// both the geoFeatures pre-check and the created service. A level or group only
+// resolves against a boundary ancestor, so when the author picked a level/group
+// but checked no explicit unit, the user's roots are injected as that boundary.
+export const resolveOuDimension = (selection = [], userRoots = []) => {
+  const ids = selection.map((item) => item.id).filter(Boolean);
+
+  const hasLevelOrGroup = ids.some((id) => isLevel(id) || isGroup(id));
+  const hasBoundary = ids.some((id) => isBoundary(id));
+
+  if (!hasLevelOrGroup || hasBoundary) {
+    return ids;
+  }
+
+  const rootIds = userRoots.map((root) => root.id).filter(Boolean);
+  return [...new Set([...rootIds, ...ids])];
+};

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -1,0 +1,20 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+// The org units the tree is scoped to: prefer the user's analytics data-view
+// org units, falling back to their data-capture org units.
+export const pickUserRoots = (me = {}) => {
+  const dataView = me?.dataViewOrganisationUnits ?? [];
+  const dataCapture = me?.organisationUnits ?? [];
+  return dataView.length ? dataView : dataCapture;
+};

--- a/src/util/orgUnits.test.js
+++ b/src/util/orgUnits.test.js
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.*/
 
-import { pickUserRoots } from "./orgUnits";
+import { pickUserRoots, resolveOuDimension } from "./orgUnits";
 
 describe("pickUserRoots", () => {
   const dataView = [{ id: "dv1" }, { id: "dv2" }];
@@ -38,5 +38,54 @@ describe("pickUserRoots", () => {
   it("returns an empty array when the user has neither", () => {
     expect(pickUserRoots({})).toEqual([]);
     expect(pickUserRoots()).toEqual([]);
+  });
+});
+
+describe("resolveOuDimension", () => {
+  const roots = [{ id: "ROOT1" }, { id: "ROOT2" }];
+
+  it("returns explicit unit ids unchanged", () => {
+    expect(resolveOuDimension([{ id: "aaa" }, { id: "bbb" }], roots)).toEqual([
+      "aaa",
+      "bbb",
+    ]);
+  });
+
+  it("injects the user's roots as the boundary for a level with no explicit unit", () => {
+    expect(resolveOuDimension([{ id: "LEVEL-lvl1" }], roots)).toEqual([
+      "ROOT1",
+      "ROOT2",
+      "LEVEL-lvl1",
+    ]);
+  });
+
+  it("injects roots for a group with no explicit boundary", () => {
+    expect(resolveOuDimension([{ id: "OU_GROUP-grp1" }], roots)).toEqual([
+      "ROOT1",
+      "ROOT2",
+      "OU_GROUP-grp1",
+    ]);
+  });
+
+  it("does not inject roots when the author checked an explicit boundary unit", () => {
+    expect(
+      resolveOuDimension([{ id: "district1" }, { id: "LEVEL-lvl1" }], roots)
+    ).toEqual(["district1", "LEVEL-lvl1"]);
+  });
+
+  it("treats a dynamic user-org-unit as its own boundary", () => {
+    expect(
+      resolveOuDimension([{ id: "USER_ORGUNIT" }, { id: "LEVEL-lvl1" }], roots)
+    ).toEqual(["USER_ORGUNIT", "LEVEL-lvl1"]);
+  });
+
+  it("does not duplicate a root that is also explicitly present", () => {
+    expect(
+      resolveOuDimension([{ id: "ROOT1" }, { id: "LEVEL-lvl1" }], roots)
+    ).toEqual(["ROOT1", "LEVEL-lvl1"]);
+  });
+
+  it("returns an empty array for an empty selection", () => {
+    expect(resolveOuDimension([], roots)).toEqual([]);
   });
 });

--- a/src/util/orgUnits.test.js
+++ b/src/util/orgUnits.test.js
@@ -1,0 +1,42 @@
+/*Copyright 2025 Esri
+Licensed under the Apache License Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+import { pickUserRoots } from "./orgUnits";
+
+describe("pickUserRoots", () => {
+  const dataView = [{ id: "dv1" }, { id: "dv2" }];
+  const dataCapture = [{ id: "dc1" }];
+
+  it("prefers the user's analytics data-view org units", () => {
+    expect(
+      pickUserRoots({
+        dataViewOrganisationUnits: dataView,
+        organisationUnits: dataCapture,
+      })
+    ).toEqual(dataView);
+  });
+
+  it("falls back to data-capture org units when the data view is empty", () => {
+    expect(
+      pickUserRoots({
+        dataViewOrganisationUnits: [],
+        organisationUnits: dataCapture,
+      })
+    ).toEqual(dataCapture);
+  });
+
+  it("returns an empty array when the user has neither", () => {
+    expect(pickUserRoots({})).toEqual([]);
+    expect(pickUserRoots()).toEqual([]);
+  });
+});

--- a/src/util/portal.js
+++ b/src/util/portal.js
@@ -132,6 +132,11 @@ export async function deletePortalItem(portalUrl, owner, itemId, token) {
   const url = `${portalUrl}/sharing/rest/content/users/${owner}/items/${itemId}/delete`;
   const data = await postForm(url, token);
   if (data?.error) {
+    // Deleting the CDF service cascade-deletes its portal item, so a follow-up
+    // "already gone" is the outcome we wanted, not a failure to surface.
+    if (/does not exist or is inaccessible/i.test(data.error.message || "")) {
+      return { success: true, itemId, alreadyDeleted: true };
+    }
     throw new Error(data.error.message || "Failed to delete the portal item.");
   }
   return data;

--- a/src/util/portal.test.js
+++ b/src/util/portal.test.js
@@ -183,6 +183,28 @@ describe("deleteConnection", () => {
     await expect(deleteConnection(baseArgs)).rejects.toThrow("no permission");
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
+
+  it("treats an already-deleted portal item as success (service delete cascaded)", async () => {
+    global.fetch
+      .mockReturnValueOnce(okJson({ status: "success" }))
+      .mockReturnValueOnce(
+        okJson({
+          error: {
+            code: 400,
+            message: "Item does not exist or is inaccessible.",
+          },
+        })
+      );
+
+    const result = await deleteConnection(baseArgs);
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.item).toEqual({
+      success: true,
+      itemId: "abc123",
+      alreadyDeleted: true,
+    });
+  });
 });
 
 describe("canPreview", () => {


### PR DESCRIPTION
## Why

PRs #60 and #61 merged 13 seconds apart in the wrong order: #60 merged `fix/post-upload-qa` → `main`, then #61 merged `58-orgunit-selection` → `fix/post-upload-qa` (instead of `main`). As a result the entire #58 org-unit selection redesign never reached `main` — it's stranded on `fix/post-upload-qa`.

This PR brings that work forward to `main`, plus a follow-up UI fix commit.

## What lands

- **#58 org-unit selection** (T1–T3): user-scoped tree roots, level/group bulk-select via `resolveOuDimension`, resolves-to preview, ADR-0002 + glossary.
- **UI fixes** (`ac2264a9`):
  - Wizard footer no longer smooshed — stepper scrolls in a flex region with a pinned, consistently spaced footer; Org Units/Data steps now responsive like the Time step.
  - Connections delete dialog buttons render (Calcite 3 `calcite-dialog` uses `footer-start`/`footer-end`, not the `calcite-modal` `primary`/`secondary` slots).
  - Discard/Remove no longer error after succeeding — `deletePortalItem` treats the service-delete cascade ("Item does not exist or is inaccessible") as success; real errors still surface. Test added.

## Verification

- `d2-app-scripts test`: 70 passed. Only the pre-existing `src/App.test.js` failure remains (`./App.js` vs `App.jsx`), unrelated to these changes.

Closes the gap left by #61 merging into the wrong base.
