### PR TITLE
Polish New Connection wizard, Summary, preview, and Connections UI

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-05-30T20:47:07.365Z\n"
-"PO-Revision-Date: 2025-05-30T20:47:07.365Z\n"
+"POT-Creation-Date: 2026-08-14T13:59:50.228Z\n"
+"PO-Revision-Date: 2026-08-14T13:59:50.231Z\n"
 
 msgid "Debug Information"
 msgstr "Debug Information"
@@ -47,6 +47,16 @@ msgstr "Configure"
 msgid "Sign In"
 msgstr "Sign In"
 
+msgid "Table-only preview"
+msgstr "Table-only preview"
+
+msgid ""
+"The selected organisation units have no geometry, so this preview shows the "
+"attribute table only with no map."
+msgstr ""
+"The selected organisation units have no geometry, so this preview shows the "
+"attribute table only with no map."
+
 msgid "Manage Connections"
 msgstr "Manage Connections"
 
@@ -85,21 +95,49 @@ msgstr "Portal URL"
 msgid "Save Configuration"
 msgstr "Save Configuration"
 
+msgid "Connection removed"
+msgstr "Connection removed"
+
+msgid "The Connection and its ArcGIS artifacts were permanently deleted."
+msgstr "The Connection and its ArcGIS artifacts were permanently deleted."
+
+msgid "Error removing Connection"
+msgstr "Error removing Connection"
+
 msgid "Add New Connection"
 msgstr "Add New Connection"
+
+msgid "Refresh"
+msgstr "Refresh"
 
 msgid "View all existing connections"
 msgstr "View all existing connections"
 
 msgid ""
 "Connections are live feeds to your DHIS2 data. The data remains in DHIS2. "
-"To delete connections, you can do so from the ArcGIS Enterprise portal."
+"You can remove connections you own directly from this page."
 msgstr ""
 "Connections are live feeds to your DHIS2 data. The data remains in DHIS2. "
-"To delete connections, you can do so from the ArcGIS Enterprise portal."
+"You can remove connections you own directly from this page."
 
 msgid "Open"
 msgstr "Open"
+
+msgid "Remove"
+msgstr "Remove"
+
+msgid "Remove Connection"
+msgstr "Remove Connection"
+
+msgid ""
+"This permanently deletes the feature layer \"{{title}}\" and will break "
+"anything using it in ArcGIS Enterprise. This action cannot be undone."
+msgstr ""
+"This permanently deletes the feature layer \"{{title}}\" and will break "
+"anything using it in ArcGIS Enterprise. This action cannot be undone."
+
+msgid "Cancel"
+msgstr "Cancel"
 
 msgid "Welcome to the"
 msgstr "Welcome to the"
@@ -128,14 +166,11 @@ msgstr "Sign In with ArcGIS Enterprise"
 msgid "View the documentation here"
 msgstr "View the documentation here"
 
-msgid "Layer created successfully"
-msgstr "Layer created successfully"
+msgid "Error creating preview"
+msgstr "Error creating preview"
 
-msgid "Your layer has been created successfully. You can now use it in ArcGIS."
-msgstr "Your layer has been created successfully. You can now use it in ArcGIS."
-
-msgid "Error creating layer"
-msgstr "Error creating layer"
+msgid "Error discarding preview"
+msgstr "Error discarding preview"
 
 msgid ""
 "Layer names cannot contain spaces or any special characters except "
@@ -150,6 +185,22 @@ msgid ""
 msgstr ""
 "The layer name you have entered already exists. Please choose a different "
 "name."
+
+msgid "Preview of {{name}}"
+msgstr "Preview of {{name}}"
+
+msgid ""
+"This preview is the real connection. Keep it to finish, or discard to "
+"delete it and continue editing."
+msgstr ""
+"This preview is the real connection. Keep it to finish, or discard to "
+"delete it and continue editing."
+
+msgid "Discard"
+msgstr "Discard"
+
+msgid "Keep"
+msgstr "Keep"
 
 msgid "Select the organisation units below to aggregate your data."
 msgstr "Select the organisation units below to aggregate your data."
@@ -160,6 +211,44 @@ msgid ""
 msgstr ""
 "Combining organisation units with different geography types is not "
 "supported. Please make separate connections for different geography types."
+
+msgid "Checking your selection…"
+msgstr "Checking your selection…"
+
+msgid "Resolves to a table-only Connection (no mapped organisation units)."
+msgstr "Resolves to a table-only Connection (no mapped organisation units)."
+
+msgid "Mixed geometry types"
+msgstr "Mixed geometry types"
+
+msgid ""
+"The selected organisation units resolve to more than one geometry type "
+"({{types}}). A Connection supports a single geometry type — remove units so "
+"only one type remains, or create separate Connections."
+msgstr ""
+"The selected organisation units resolve to more than one geometry type "
+"({{types}}). A Connection supports a single geometry type — remove units so "
+"only one type remains, or create separate Connections."
+
+msgid "Some units have no geometry"
+msgstr "Some units have no geometry"
+
+msgid ""
+"Some selected organisation units have no geometry. They will be included as "
+"table-only rows in the Connection."
+msgstr ""
+"Some selected organisation units have no geometry. They will be included as "
+"table-only rows in the Connection."
+
+msgid "Table-only Connection"
+msgstr "Table-only Connection"
+
+msgid ""
+"None of the selected organisation units have geometry. This will create a "
+"table-only Connection with no map layer."
+msgstr ""
+"None of the selected organisation units have geometry. This will create a "
+"table-only Connection with no map layer."
 
 msgid "Data"
 msgstr "Data"
@@ -184,6 +273,13 @@ msgstr ""
 "Create a title and description for your new ArcGIS Enterprise Layer. Both "
 "fields may be changed later in ArcGIS Enterprise."
 
+msgid ""
+"The suggested name and description below are generated automatically from "
+"your selection, check for accuracy and edit as needed."
+msgstr ""
+"The suggested name and description below are generated automatically from "
+"your selection, check for accuracy and edit as needed."
+
 msgid "Layer Name"
 msgstr "Layer Name"
 
@@ -195,3 +291,9 @@ msgstr "Layer Description"
 
 msgid "Enter a description for your layer"
 msgstr "Enter a description for your layer"
+
+msgid "Preview"
+msgstr "Preview"
+
+msgid "Next"
+msgstr "Next"

--- a/src/components/PreviewPanel.jsx
+++ b/src/components/PreviewPanel.jsx
@@ -24,7 +24,7 @@ import "@arcgis/core/assets/esri/themes/light/main.css";
 
 const Container = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: ${(props) => (props.$horizontal ? "row" : "column")};
   gap: 1rem;
   flex: 1;
   min-height: 0;
@@ -32,12 +32,14 @@ const Container = styled.div`
 
 const MapSurface = styled.div`
   flex: 1;
+  min-width: 0;
   min-height: 260px;
   border: 1px solid var(--calcite-ui-border-3);
 `;
 
 const TableSurface = styled.div`
   flex: 1;
+  min-width: 0;
   min-height: 220px;
   border: 1px solid var(--calcite-ui-border-3);
 `;
@@ -86,7 +88,7 @@ const PreviewPanel = ({ serviceUrl, hasGeometry }) => {
   }, [serviceUrl, hasGeometry]);
 
   return (
-    <Container>
+    <Container $horizontal={hasGeometry}>
       {hasGeometry ? (
         <MapSurface ref={mapRef} />
       ) : (

--- a/src/pages/Connections.jsx
+++ b/src/pages/Connections.jsx
@@ -39,10 +39,12 @@ import { getSortIndicator } from "../util/sort";
 
 const StyledContainer = styled.div`
   padding: 1rem;
-  height: 100vh;
+  height: 100%;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  overflow: hidden;
 `;
 
 const StyledPageHeader = styled.h1`
@@ -73,6 +75,10 @@ const Connections = () => {
 
   const fetchServices = async () => {
     setIsRefreshing(true);
+    // A fast refresh looks like a glitch, so keep the spinner up long enough to
+    // read as a full rotation.
+    const start = Date.now();
+    const MIN_SPIN_MS = 800;
     try {
       const response = await queryForServices(
         userCredential.server,
@@ -80,6 +86,12 @@ const Connections = () => {
       );
       setServices(response || []);
     } finally {
+      const elapsed = Date.now() - start;
+      if (elapsed < MIN_SPIN_MS) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, MIN_SPIN_MS - elapsed)
+        );
+      }
       setIsRefreshing(false);
     }
   };
@@ -237,19 +249,20 @@ const Connections = () => {
       </div>
       <div>
         {i18n.t(
-          "Connections are live feeds to your DHIS2 data. The data remains in DHIS2. You can remove Connections you own directly from this page."
+          "Connections are live feeds to your DHIS2 data. The data remains in DHIS2. You can remove connections you own directly from this page."
         )}
       </div>
 
-      {services.length > 0 && (
-        <CalciteTable
-          style={{
-            maxHeight: "calc(75vh - 200px)",
-          }}
-          numbered
-          interactionMode="static"
-          striped
-        >
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          overflowY: "auto",
+          overflowX: "hidden",
+        }}
+      >
+        {services.length > 0 && (
+        <CalciteTable numbered interactionMode="static" striped>
           <CalciteTableRow
             slot="table-header"
             alignment="center"
@@ -330,7 +343,8 @@ const Connections = () => {
             </CalciteTableRow>
           ))}
         </CalciteTable>
-      )}
+        )}
+      </div>
 
       <CalciteDialog
         modal

--- a/src/pages/NewConnection.jsx
+++ b/src/pages/NewConnection.jsx
@@ -19,6 +19,8 @@ import {
   CalciteStepper,
   CalciteStepperItem,
   CalciteInput,
+  CalciteTextArea,
+  CalciteLabel,
   CalciteNotice,
 } from "@esri/calcite-components-react";
 
@@ -56,14 +58,16 @@ import { useNavigate } from "react-router-dom";
 
 import ReactJsonView from "@microlink/react-json-view";
 
-const StyledCalciteInputText = styled(CalciteInput)`
-  --calcite-input-prefix-size: 140px;
-  width: 400px;
+const FieldLabelText = styled.span`
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
 `;
 
 const Description = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
   justify-content: left;
   text-align: left;
   color: dark grey;
@@ -441,10 +445,12 @@ const NewConnection = ({
     <div
       style={{
         padding: "1rem",
-        height: "100vh",
+        height: "100%",
+        boxSizing: "border-box",
         display: "flex",
         flexDirection: "column",
         justifyContent: "space-between",
+        overflow: "hidden",
       }}
     >
       {previewHandle ? (
@@ -463,11 +469,11 @@ const NewConnection = ({
                 name: previewHandle.serviceName,
               })}
             </h2>
-            <Description>
+            <div style={{ fontSize: "16px", color: "dark grey" }}>
               {i18n.t(
-                "This preview is the real Connection. Keep it to finish, or Discard to delete it and continue editing."
+                "This preview is the real connection. Keep it to finish, or discard to delete it and continue editing."
               )}
-            </Description>
+            </div>
             <PreviewPanel
               serviceUrl={previewHandle.serviceUrl}
               hasGeometry={previewHandle.hasGeometry}
@@ -508,7 +514,14 @@ const NewConnection = ({
         </>
       ) : (
         <>
-          <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+          <div
+            style={{
+              flex: 1,
+              minHeight: 0,
+              overflowY: "auto",
+              overflowX: "hidden",
+            }}
+          >
           <CalciteStepper
         ref={stepperRef}
         numbered
@@ -529,13 +542,11 @@ const NewConnection = ({
                 "Select the organisation units below to aggregate your data."
               )}
             </div>
-            <br />
             <div>
               {i18n.t(
                 "Combining organisation units with different geography types is not supported. Please make separate connections for different geography types."
               )}
             </div>
-            <br />
           </Description>
           <OrgUnitDimensionWrapper onChange={setSelectedOrgUnits} />
           {selectedOrgUnits.length > 0 && (
@@ -606,7 +617,6 @@ const NewConnection = ({
             >
               {i18n.t("Select data items to include in your ArcGIS Layer. ")}
             </div>
-            <br />
             <div>
               {i18n.t(
                 "Note: Data elements with conflicting aggregation types will cause the layer creation to fail. If you would like to only connect geographies for organisation units, do not select any data items."
@@ -654,13 +664,11 @@ const NewConnection = ({
             >
               {i18n.t("Select the time period for your selected data.")}
             </div>
-            <br />
             <div>
               {i18n.t(
                 "Data may be additionally filtered by time in ArcGIS Enterprise applications and maps."
               )}
             </div>
-            <br />
           </Description>
           <div
             style={{
@@ -685,38 +693,53 @@ const NewConnection = ({
         </CalciteStepperItem>
         <CalciteStepperItem heading="Summary">
           <Description>
-            {i18n.t(
-              "Create a title and description for your new ArcGIS Enterprise Layer. Both fields may be changed later in ArcGIS Enterprise."
-            )}
-            <br />
+            <div
+              style={{
+                fontSize: "16px",
+                fontWeight: "bold",
+              }}
+            >
+              {i18n.t(
+                "Create a title and description for your new ArcGIS Enterprise Layer. Both fields may be changed later in ArcGIS Enterprise."
+              )}
+            </div>
+            <div>
+              {i18n.t(
+                "The suggested name and description below are generated automatically from your selection, check for accuracy and edit as needed."
+              )}
+            </div>
           </Description>
           <div
             style={{
               display: "flex",
               flexDirection: "column",
               gap: "1rem",
-              alignItems: "flex-start",
+              alignItems: "stretch",
+              width: "100%",
+              maxWidth: "720px",
             }}
           >
-            <StyledCalciteInputText
-              prefixText={i18n.t("Layer Name")}
-              value={layerName}
-              // onCalciteInputInput={(event) => setLayerName(event.target.value)}
-              onCalciteInputInput={(event) => handleLayerNameChange(event)}
-              placeholder={i18n.t("Enter a unique layer name")}
-            />
-            <StyledCalciteInputText
-              prefixText={i18n.t("Layer Description")}
-              value={layerDescription}
-              style={{
-                width: "65%",
-              }}
-              onCalciteInputInput={(event) => {
-                setDescriptionEdited(true);
-                setLayerDescription(event.target.value);
-              }}
-              placeholder={i18n.t("Enter a description for your layer")}
-            />
+            <CalciteLabel style={{ width: "100%" }}>
+              <FieldLabelText>{i18n.t("Layer Name")}</FieldLabelText>
+              <CalciteInput
+                style={{ fontFamily: "var(--calcite-sans-family)" }}
+                value={layerName}
+                onCalciteInputInput={(event) => handleLayerNameChange(event)}
+                placeholder={i18n.t("Enter a unique layer name")}
+              />
+            </CalciteLabel>
+            <CalciteLabel style={{ width: "100%" }}>
+              <FieldLabelText>{i18n.t("Layer Description")}</FieldLabelText>
+              <CalciteTextArea
+                value={layerDescription}
+                rows={4}
+                placeholder={i18n.t("Enter a description for your layer")}
+                onCalciteTextAreaInput={(event) => {
+                  setDescriptionEdited(true);
+                  setLayerDescription(event.target.value);
+                }}
+              />
+            </CalciteLabel>
           </div>
         </CalciteStepperItem>
       </CalciteStepper>

--- a/src/util/suggestions.js
+++ b/src/util/suggestions.js
@@ -16,13 +16,17 @@ const MAX_NAME_LENGTH = 50;
 const displayNameOf = (item) =>
   item?.name ?? item?.displayName ?? item?.label ?? item?.id ?? "";
 
-const nameWithMore = (items) => {
-  if (!items.length) {
-    return "";
+// "A", "A and B", "A, B and C" — lists every name so the description spells the
+// selection out rather than hiding extras behind an "and N more" count.
+const listNames = (items) => {
+  const names = items.map(displayNameOf).filter(Boolean);
+  if (names.length <= 1) {
+    return names[0] ?? "";
   }
-  const first = displayNameOf(items[0]);
-  const more = items.length - 1;
-  return more > 0 ? `${first} and ${more} more` : first;
+  if (names.length === 2) {
+    return `${names[0]} and ${names[1]}`;
+  }
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
 };
 
 // Sanitize to an ArcGIS-safe service name: disallowed runs become "_",
@@ -49,32 +53,38 @@ export const applyNameSuffix = (base, occurrence) => {
   return `${trimmed.replace(/_+$/, "")}${suffix}`;
 };
 
-// Suggested service name from the selection: first data item + first org unit
-// + first period, with a short "_plusN" count when multiple are selected.
+// Org units are listed in the name only up to this many; beyond it the name
+// would get unwieldy (e.g. 10 districts), so they are dropped and left to the
+// description.
+const ORG_UNITS_IN_NAME_LIMIT = 3;
+
+// Suggested service name from the selection: first data item, the org units
+// (only when few enough to stay readable), and first period. Extra data
+// items/periods and large org-unit sets are reflected in the description, not
+// the name.
 export const suggestConnectionName = ({
   dataItems = [],
   orgUnits = [],
   periods = [],
 } = {}) => {
-  const parts = [dataItems[0], orgUnits[0], periods[0]]
-    .filter(Boolean)
-    .map(displayNameOf)
+  const orgUnitParts =
+    orgUnits.length > 0 && orgUnits.length <= ORG_UNITS_IN_NAME_LIMIT
+      ? orgUnits.map(displayNameOf)
+      : [];
+
+  const parts = [displayNameOf(dataItems[0]), ...orgUnitParts, displayNameOf(periods[0])]
     .filter(Boolean);
 
   if (!parts.length) {
     return "";
   }
 
-  const extra =
-    Math.max(0, dataItems.length - 1) +
-    Math.max(0, orgUnits.length - 1) +
-    Math.max(0, periods.length - 1);
-
-  const base = sanitizeName(parts.join("_"));
-  return capName(extra > 0 ? `${base}_plus${extra}` : base);
+  return capName(sanitizeName(parts.join("_")));
 };
 
-// Readable, editable default description for the Summary step.
+// Readable, editable default description for the Summary step. Every selected
+// data item, org unit, and period is listed so the author can see exactly what
+// the Connection covers.
 export const suggestDescription = ({
   dataItems = [],
   orgUnits = [],
@@ -85,10 +95,10 @@ export const suggestDescription = ({
   }
 
   const lead = dataItems.length
-    ? nameWithMore(dataItems)
+    ? listNames(dataItems)
     : "Organisation unit data";
-  const where = orgUnits.length ? ` in ${nameWithMore(orgUnits)}` : "";
-  const when = periods.length ? ` for ${nameWithMore(periods)}` : "";
+  const where = orgUnits.length ? ` in ${listNames(orgUnits)}` : "";
+  const when = periods.length ? ` for ${listNames(periods)}` : "";
 
   return `${lead}${where}${when}.`;
 };

--- a/src/util/suggestions.test.js
+++ b/src/util/suggestions.test.js
@@ -59,14 +59,39 @@ describe("suggestConnectionName", () => {
     ).toBe("Malaria_Sierra_Leone_2020");
   });
 
-  it("appends a short count when more than one item is selected", () => {
+  it("uses only the first of each dimension, without a count suffix", () => {
     expect(
       suggestConnectionName({
         dataItems: [{ name: "Malaria" }, { name: "TB" }],
         orgUnits: [{ name: "Bo" }],
         periods: [{ name: "2020" }, { name: "2021" }],
       })
-    ).toBe("Malaria_Bo_2020_plus2");
+    ).toBe("Malaria_Bo_2020");
+  });
+
+  it("lists up to three org units in the name", () => {
+    expect(
+      suggestConnectionName({
+        dataItems: [{ name: "Malaria" }],
+        orgUnits: [{ name: "Bo" }, { name: "Bombali" }, { name: "Kono" }],
+        periods: [{ name: "2020" }],
+      })
+    ).toBe("Malaria_Bo_Bombali_Kono_2020");
+  });
+
+  it("omits org units from the name when more than three are selected", () => {
+    expect(
+      suggestConnectionName({
+        dataItems: [{ name: "Malaria" }],
+        orgUnits: [
+          { name: "Bo" },
+          { name: "Bombali" },
+          { name: "Kono" },
+          { name: "Kailahun" },
+        ],
+        periods: [{ name: "2020" }],
+      })
+    ).toBe("Malaria_2020");
   });
 
   it("falls back to displayName", () => {
@@ -104,14 +129,14 @@ describe("suggestDescription", () => {
     ).toBe("Malaria in Sierra Leone for 2020.");
   });
 
-  it("summarizes additional items with a count", () => {
+  it("lists every selected item by name", () => {
     expect(
       suggestDescription({
         dataItems: [{ name: "Malaria" }, { name: "TB" }],
-        orgUnits: [{ name: "Sierra Leone" }],
+        orgUnits: [{ name: "Sierra Leone" }, { name: "Bombali" }, { name: "Bo" }],
         periods: [{ name: "2020" }],
       })
-    ).toBe("Malaria and 1 more in Sierra Leone for 2020.");
+    ).toBe("Malaria and TB in Sierra Leone, Bombali and Bo for 2020.");
   });
 
   it("describes a geometry/table-only selection with no data items", () => {


### PR DESCRIPTION
Polish the New Connection wizard, Summary step, preview, and Connections page.

## Wizard layout
- Each step now fits the shell content region: a single vertical scroll where needed (org units / data), no double scrollbar and no horizontal scrollbar.
- Tightened spacing between descriptor lines (removed extra blank lines).

## Suggested name & description
- Dropped the confusing `_plusN` suffix from the suggested name.
- Name lists up to 3 org units and omits them entirely when more than 3 are selected (keeps it readable).
- Description spells out the full selection instead of "and N more".

## Summary step
- Bolded the heading to match the other steps.
- Added a note that the name/description are auto-generated and should be checked for accuracy.
- Layer Name and Layer Description now share a consistent design: prominent labels stacked above each field.
- Description is a multiline text box; name field widened.
- Fixed the font mismatch between the name input and description textarea (both use `--calcite-sans-family`).

## Preview
- Map on the left, table on the right when there is geometry; falls back to the original full-width table for table-only connections.
- Removed extra space under the "Preview of ..." heading; lowercased "connection"/"discard" in the copy.

## Connections page
- Container fills the page with the table as the only scroll region.
- Lowercased the second "connections" in the intro text.
- Refresh button now holds a minimum spin so a fast refresh reads as intentional rather than a flicker.

## Testing
- `suggestions` unit tests updated and passing; `npm run build` succeeds.
- Layout / preview / refresh changes are presentational and verified via build; manual smoke test recommended.
